### PR TITLE
docs: update reference API docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,31 +1,11 @@
 # API reference
 
 ::: bartiq
-    handler: python
-    options:
-      show_source: false
-
-::: bartiq.compilation
-    handler: python
-    options:
-      show_source: false
 
 ::: bartiq.precompilation
-    handler: python
-    options:
-      show_source: false
 
 ::: bartiq.symbolics
-    handler: python
-    options:
-      show_source: false
 
 ::: bartiq.routing
-    handler: python
-    options:
-      show_source: false
 
 ::: bartiq.errors
-    handler: python
-    options:
-      show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,17 @@ plugins:
   - link-marker
   - open-in-new-tab
   - search
-  - mkdocstrings
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            show_source: false
+            separate_signature: true
+            line_length: 60
+            modernize_annotations: true
+            show_signature_annotations: true
+            show_root_heading: true
   - mkdocs-jupyter:
       include_source: True
 


### PR DESCRIPTION
What this does:

- Tidies up the configuration options to define them globally, rather than at the module level.
- Removes API documentation for `bartiq.compilation`, since all of these are exposed to `bartiq`, and so need not be documented twice.
- Improves the rendering of the API docs by:
    1. Separates the Markdown heading line from the signature definition, via `separate_signature` option
    2. Limits the signature documentation line length to avoid long strings of signatures and force aggressive new lining via `line_length`
    3. Uses modernised annotations using `modernize_annotations`
    4. Adds annotations to signature docs using `show_signature_annotations`
    5. Structure docs by module using `show_root_heading`

Taking all of the above rendering config, what was:

<img width="1072" alt="Screenshot 2024-05-03 at 12 23 26" src="https://github.com/PsiQ/bartiq/assets/20857520/7d03d35c-75d2-4449-a46f-19b060cf78d6">

now looks like:

<img width="1062" alt="Screenshot 2024-05-03 at 12 23 45" src="https://github.com/PsiQ/bartiq/assets/20857520/83a38ae1-409b-4d0c-ac6f-0e2507d6a234">

(Note changes in both the documentation of the function **and** the TOC sidebar structure)

References:
- mkdocstrings-python configuration options: https://mkdocstrings.github.io/python/usage/