### PR TITLE
docs: compilation and precompilation docs

### DIFF
--- a/docs/concepts/compilation.md
+++ b/docs/concepts/compilation.md
@@ -1,1 +1,61 @@
 # Compilation
+
+Here we will describe how the compilation process in Bartiq works.
+Please keep in mind, that while we try to keep this page up-to-date, in the end the code is the only source-of-truth. If you notice any discrepancies, between what's described here and how Bartiq behaves, please [create an issue](https://github.com/PsiQ/bartiq/issues)!
+
+## Bird's eye perspective on compilation
+
+Compilation consists of the following steps:
+
+1. Precompilation - ensures that Routine has all the components needed for the rest of the compilation process.
+2. Routine-to-function conversion – maps routine to functions (see glossary), on which compilation is performed.
+3. Function compilation – compiles all the functions to a 
+
+
+## Step 1 – precompilation
+
+This stage "precompiles" the routine by making a series of reasonable assumptions about what the user would have
+wanted when they have not been explicit. For example, insertion of "trivial" routines for known subroutines or
+"filling out" routines which have only been partially defined. It is expected that this precompilation stage will
+grow as more sensible defaults are requested by users. For more details please visit [precompilation page](precompilation.md).
+
+## Step 2 – routine to function conversion
+
+Before being compiled, routines must first be mapped to compilable function objects (see glossary).
+At this stage, we perform a number of steps to map the routines into functions that are ready for
+compilation:
+
+1. Map routines to "local" functions: first, we simply map the routines to functions in a local manner, whereby they
+   are unaware of their location within the full definition. To do this we convert `Routine` objects to `RoutineWithFunction`, which augments Routine class with a `symbolic_function` field.
+2. Map "local" functions to "global" functions: we tell the functions where they live in the definition, thereby
+   making each parameter and any named functions unique within the definition by prepending it with its full path from the root.
+3. Pull in input register sizes: in order to allow for input register sizes to be compiled properly, low-level input
+   register sizes must be renamed by the size parameters used by high-level registers. This process is referred to as
+   "pulling in" those high-level register sizes.
+4. Push out output register sizes: to ensure correct compilation for output register sizes, those associated with
+   low-level routines must be "push out" to either other low-level routines or eventually high-level routines.
+5. Parameter inheritance: lastly, any high-level routines parameters are passed down to low-level routines by
+   substituting the low-level routine parameters with the high-level ones.
+
+Once this is complete, each subroutine has an associated function, which is expressed in terms of global variables.
+
+## Step 3 – functions compilation
+
+At the start of this stage routine is annotated with functions which contain all the required information in the global namespace. Compilation starts from the leafs, each routine can only be compiled once all of its children have been compiled ("bottom-up"). This stage contains a number of sub-steps:
+
+1. Compile functions of self and children (non-leaves only): for leaves, no function compilation is necessary, but
+   non-leaves need to update information in associated function with the information contained in their children's functions.
+2. Undo register size pulling and pushing: to ensure a correct local estimate, we must "undo" the pulling in and pushing
+   out of register size params done during routine-to-function conversion.
+3. Derefence global namespace: again, to ensure a correct local routine definition, we dereference the global
+   namespace. This means dropping the path prefix from all the variables: e.g.: `root.child.gchild.N` would become `N`.
+4. Map function to routine: lastly, once the correct local function has been compiled, we map the function object
+   back to a routine by updating routine's attribute and removing associated function object.
+
+
+## Glossary
+
+- **Function**: functions are objects defined with `SymbolicFunction` class. Each function has a defined set of inputs and outputs. Inputs are independent variables, whic are basically bare symbols, without any structure. Outputs are dependent variables, meaning they are variables defined by expressions which are dependent on the input variables.
+- **Global and local**: in this context "global" means "defined at the root-level of the routine we compile". Local, on the contrary, means "defined for the subroutine currently being operated on". Intuitively, global parameters are those that correspond to the domain of the problem that we are trying to solve, e.g.: number of bits of precision of QPE. On the other hand, local parameters correspond to the implementation details of the algorithm we are analyzing, e.g.: size of the QFT routine in QPE. Compilation process allows us to express all the local parameters in the algorithm in terms of the global parameters.
+
+

--- a/docs/concepts/precompilation.md
+++ b/docs/concepts/precompilation.md
@@ -1,1 +1,29 @@
 # Precompilation
+
+Precompilation is a collection of steps we perform prior to the proper compilation. They apply a series of reasonable assumptions about what the user would have wanted when they have not been explicit in defining their routine.
+
+## Usage
+
+
+By default precompilation is performed in the `compile_routine` method with a set of default stages. However, API for precompilation has been designed to make customizing precompilation stages easy. 
+
+First, user can define their own precompilation stages. All precompilation stages have the same interface – as inputs they take `Routine` and `SymbolicBackend` and they modify the provided `Routine` object in place. Therefore adding a custom stage requires simply writing a method which complies with this interface.
+
+Second, the choice and order of the stages used can be changed by passing them explicitly through `precompilation_stages` argument of the `compile_routine` method.
+
+Precompilation can also be performed outside of the `compile_routine` by using `precompile` method. 
+
+
+## Precompilation stages
+
+`bartiq.precompilation` module currently contains the stages listed below. They are applied by default in the order provided.
+
+1. Add default properties: adds default properties for the subroutines of certain type. Right now it only acts on the routines of type `merge`. If the size of the output port is not specified, it sets it to the sume of the sizes of the input ports.
+
+2. Add default additive resources: if the user defined resource of type `additive` anywhere in any of the subroutines, it implies that this resource should be included in their parent as a sum of the resources of their children. An example of an additive resource is T gate – if a routine contains two children A and B, which have resource `T` defined, equal to `N_A` and `N_B`, after performing this stage, the parent will also have resource `T` with the cost equal to `N_A + N_B`.
+
+3. Add passthrough placeholder: passthrough is a situation where we have a routine, which has a connection that goes straight from the input to output port, without touching any subroutines on its way. Currently Bartiq can't handle such cases in the compilation process and in order to get around in the precompilation process we add a "virtual" routine of type `passthrough`, which is not associated with any real operation (it can be thought of as an "identity gate"), but which removes the passthrough from the topology of the routine.
+
+4. Removing non-root non-leaf input register sizes: currently Bartiq cannot handle situation where port get a size assigned twice. For example, the first assigned comes from how the port is defined and the second comes from the connection (i.e. we derive the size of the port based on the fact that we know the size of the port on the other side of the connection). In order to alleviate this issue, in this precompilation step we set to `None` sizes of the input ports of all the routines which are neither root nor leaf.
+
+5. Unroll wildcarded resources: if wildcard symbol (`~`) is detected in the resource, it gets replaced with the proper expression. An example usage would be when a routine has multiple children and we only to add the costs of the children with the name fitting certain pattern, e.g.: `cost = sum(select_~.cost)` would only add `cost` for the children whose names start with `select_` and that have `cost` resource defined.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,4 +11,4 @@ Debugging `bartiq` is not always straightforward, so please see below for a numb
 	- If not, consider creating one!
 	- Submitting issue is the most transparent way to give us feedback – even if something works, but is extremely unintuitive, we want to make it easier to use. The goal of this tool is to save you time, not waste it on unhelpful error messages.
 
-- If you see a `passthrough` in your error message, but you don't know where it came from, passthroughs are added automatically during one of the precompilation stages.
+- If you see a `passthrough` in your error message, but you don't know where it came from, passthroughs are added automatically during one of the precompilation stages (see [precompilation page](concepts/precompilation.md) for more details).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,9 @@ nav:
       - tutorials/index.md
       - tutorials/01_basic_example.ipynb
       - tutorials/02_alias_sampling_basic.ipynb
+  - Concepts:
+      - concepts/compilation.md
+      - concepts/precompilation.md
   - troubleshooting.md
   - limitations.md
   - reference.md

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -12,74 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Bartiq compilation module.
-Glossary:
-
-- Routine: a topological definition of a quantum circuit. In this definition, each quantum subroutine is represented
-  as a routine with input and/or output ports, representing the qubit registers the inputs and/or outputs
-  respectively. Qubit register flows between subroutines are represented by connections between subroutine ports.
-  Root-level ports represent input/output quantum registers of the top-level quantum routine.
-  Each subroutine also contains information about its quantum resource costs
-- Estimate: the output of compiling a circuit with an assignment of routines. After compilation, each
-  routines's resources and register sizes now represent the cost of the routine in terms of the estimate's
-  high-level parameters (rather than the parameters of the original routine).
-
-Estimate compilation is a complex procedure that involves a number of interacting, subtle steps.
-At a high level there are three major stages to the process:
-
-1. Routine precompilation
-2. Routine-to-function conversion
-3. Estimate compilation
-
-Below describes the main concepts in each of these in more detail.
-
-1. Routine precompilation
-This stage "precompiles" the routine by making a series of reasonable assumptions about what the user would have
-wanted when they have not been explicit. For example, insertion of "trivial" routines for known subroutines or
-"filling out" routines which have only been partially defined. (It is expected that this precompilation stage will
-grow as more sensible defaults are requested by users.)
-This stage is applied via `run_estimate_precompilation`
-
-2. Routine-to-function conversion
-Before being compiled, routines must first be mapped to compilable function objects.
-At this stage, we perform a number of steps to map the routines into functions that are ready for
-compilation:
-
-1. Map routines to "local" functions: first, we simply map the routines to functions in a local manner, whereby they
-   are unaware of their location within the full definition. We use RoutineWithFunction, which augments Routine
-   class with a `symbolic_function` field.
-2. Map "local" functions to "global" functions: next, we tell the functions where they live in the definition, thereby
-   making each parameter and any named functions unique within the definition.
-3. Pull in input register sizes: in order to allow for input register sizes to be compiled properly, low level input
-   register sizes must be renamed by the size parameters used by high-level registers. This process is referred to as
-   "pulling in" those high-level register sizes.
-4. Push out output register sizes: to ensure correct compilation for output register sizes, those associated with
-   low-level routines must be "push out" to either other low-level routines or eventually high-level routines.
-5. Parameter inheritance: lastly, any high-level routines parameters are passed down to low-level estimators by
-   substituting the low-level routine parameters with the high-level ones.
-
-Once this is complete, the final function is stored back as one of the routine's attributes.
-This stage is applied via `_map_estimators_to_functions`
-
-3. Estimate compilation
-
-Lastly, the entire estimate is compiled. Compilation occurs at a routine-local level, bottom-to-top, such that each
-routine's estimate is compiled strictly after all its children's estimates have been compiled. This stage also
-contains a number of sub-steps:
-
-1. Compile functions of self and children (non-leaves only): for leaves, no function compilation is necessary, but for
-   non-leaves we must compile our own function with those of our direct descendent children.
-2. Undo register size pulling and pushing: to ensure a correct local estimate, we must "undo" the pulling in and pushing
-   out of register size params done during routine-to-function conversion.
-3. Derefence global namespace: again, to ensure a correct local routine definition, we dereference the global
-   namespace.
-4. Map function to routine: lastly, once the correct local function has been compiled, we map the function object
-   back to a routine and update routine's attribute
-
-This stage is applied via `_compile_routine_with_functions`
-
-"""
-
 from typing import Any, Optional, cast, overload
 
 from .. import Port, Routine
@@ -155,22 +87,20 @@ def _compile_routine(
     global_functions: Optional[list[str]] = None,
     functions_map: Optional[FunctionsMap] = None,
 ):
-    # NOTE: Old compilation algorithm was written with the assumption that root is always an empty string.
-    # The fact that remove the name and then add it back at the end is a hack solution and needs to be fixed in future.
     root_name = routine.name
     routine.name = ""
     precompile(routine, precompilation_stages=precompilation_stages, backend=backend)
 
     # NOTE: This step must be completed BEFORE we start to compile the functions, as parents must be allowed to
     # update their childrens' functions (to support parameter inheritance).
-    routine_with_functions = _add_func_to_routine(routine, global_functions, backend)
+    routine_with_functions = _add_function_to_routine(routine, global_functions, backend)
 
     compiled_routine_with_funcs = _compile_routine_with_functions(routine_with_functions, functions_map, backend)
     compiled_routine_with_funcs.name = root_name
     return compiled_routine_with_funcs.to_routine()
 
 
-def _add_func_to_routine(
+def _add_function_to_routine(
     routine: Routine, global_functions: Optional[list[str]], backend: SymbolicBackend[T_expr]
 ) -> RoutineWithFunction[T_expr]:
     """Converts each routine to a symbolic function."""

--- a/src/bartiq/precompilation/__init__.py
+++ b/src/bartiq/precompilation/__init__.py
@@ -15,10 +15,10 @@
 from ._core import default_precompilation_stages, precompile
 from .stages import (
     AddPassthroughPlaceholder,
-    add_default_additive_costs,
+    add_default_additive_resources,
     add_default_properties,
     remove_non_root_container_input_register_sizes,
-    unroll_wildcarded_costs,
+    unroll_wildcarded_resources,
 )
 
 __all__ = [
@@ -26,7 +26,7 @@ __all__ = [
     "default_precompilation_stages",
     "remove_non_root_container_input_register_sizes",
     "add_default_properties",
-    "add_default_additive_costs",
-    "unroll_wildcarded_costs",
+    "add_default_additive_resources",
+    "unroll_wildcarded_resources",
     "AddPassthroughPlaceholder",
 ]

--- a/src/bartiq/precompilation/_core.py
+++ b/src/bartiq/precompilation/_core.py
@@ -18,13 +18,13 @@ from .. import Routine
 from ..symbolics.backend import SymbolicBackend
 from .stages import (
     AddPassthroughPlaceholder,
-    add_default_additive_costs,
+    add_default_additive_resources,
     add_default_properties,
     remove_non_root_container_input_register_sizes,
-    unroll_wildcarded_costs,
+    unroll_wildcarded_resources,
 )
 
-PrecompilationStage = Callable[[Routine, SymbolicBackend], Routine]
+PrecompilationStage = Callable[[Routine, SymbolicBackend], None]
 
 
 def precompile(
@@ -33,9 +33,9 @@ def precompile(
     """A precompilation stage that transforms a routine prior to estimate compilation.
 
     If no precompilation stages are specified, the following precompilation stages are performed by default (in order):
-    1. Adds default costs and register sizes for the following routine types:
+    1. Adds default resources and register sizes for the following routine types:
       - `merge`
-    2. Adds additive costs to routines if there's an additive cost in any of the children.
+    2. Adds additive resources to routines if there's an additive resources in any of the children.
     3. Adds "fake routines" when passthrough is detected.
     4. Removes input register sizes from non-root routines as they will be derived from the connected output ports
         in the compilation process.
@@ -61,8 +61,8 @@ def default_precompilation_stages():
     """Default suite of precompilation stages."""
     return [
         add_default_properties,
-        add_default_additive_costs,
+        add_default_additive_resources,
         AddPassthroughPlaceholder().add_passthrough_placeholders,
         remove_non_root_container_input_register_sizes,
-        unroll_wildcarded_costs,
+        unroll_wildcarded_resources,
     ]

--- a/tests/precompilation/test_precompile.py
+++ b/tests/precompilation/test_precompile.py
@@ -19,9 +19,9 @@ from bartiq.precompilation import precompile
 from bartiq.precompilation.stages import (
     AddPassthroughPlaceholder,
     BartiqPrecompilationError,
-    add_default_additive_costs,
+    add_default_additive_resources,
     add_default_properties,
-    unroll_wildcarded_costs,
+    unroll_wildcarded_resources,
 )
 
 from ..utilities import routine_with_passthrough, routine_with_two_passthroughs
@@ -306,7 +306,7 @@ PRECOMP_TEST_CASES = [
             ],
         },
     ),
-    # Checks if default additive costs are being added correctly
+    # Checks if default additive resources are being added correctly
     (
         {
             "name": "",
@@ -358,7 +358,7 @@ PRECOMP_TEST_CASES = [
                 }
             },
         },
-        [add_default_additive_costs],
+        [add_default_additive_resources],
         {
             "name": "",
             "type": None,
@@ -424,7 +424,7 @@ PRECOMP_TEST_CASES = [
 
 
 @pytest.mark.parametrize("input_dict, precompilation_stages, expected_dict", PRECOMP_TEST_CASES)
-def test_precompile_adds_additive_costs(input_dict, precompilation_stages, expected_dict, backend):
+def test_precompile_adds_additive_resources(input_dict, precompilation_stages, expected_dict, backend):
     input_routine = Routine(**input_dict)
     precompiled_routine = precompile(input_routine, precompilation_stages=precompilation_stages, backend=backend)
     assert precompiled_routine.model_dump(exclude_unset=True) == expected_dict
@@ -728,11 +728,13 @@ WILDCARD_TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize("input_dict, expected_cost", WILDCARD_TEST_CASES)
-def test_precompile_handles_wildcards(input_dict, expected_cost, backend):
+@pytest.mark.parametrize("input_dict, expected_resource", WILDCARD_TEST_CASES)
+def test_precompile_handles_wildcards(input_dict, expected_resource, backend):
     input_routine = Routine(**input_dict)
-    precompiled_routine = precompile(input_routine, precompilation_stages=[unroll_wildcarded_costs], backend=backend)
-    assert precompiled_routine.resources[expected_cost[0]].value == expected_cost[1]
+    precompiled_routine = precompile(
+        input_routine, precompilation_stages=[unroll_wildcarded_resources], backend=backend
+    )
+    assert precompiled_routine.resources[expected_resource[0]].value == expected_resource[1]
 
 
 def test_precompile_handles_passthroughs(backend):
@@ -863,10 +865,10 @@ KNOWN_BUGGY_WILDCARD_CASES = [
 ]
 
 
-@pytest.mark.parametrize("input_dict, expected_cost, failure_message", KNOWN_BUGGY_WILDCARD_CASES)
-def test_precompile_with_wildcard_fails(input_dict, expected_cost, failure_message):
+@pytest.mark.parametrize("input_dict, expected_resource, failure_message", KNOWN_BUGGY_WILDCARD_CASES)
+def test_precompile_with_wildcard_fails(input_dict, expected_resource, failure_message):
     pytest.xfail(failure_message)
     input_routine = Routine(**input_dict)
 
-    precompiled_routine = precompile(input_routine, precompilation_stages=[unroll_wildcarded_costs])
-    assert precompiled_routine.resources["total_cost"].value == expected_cost
+    precompiled_routine = precompile(input_routine, precompilation_stages=[unroll_wildcarded_resources])
+    assert precompiled_routine.resources["total_cost"].value == expected_resource


### PR DESCRIPTION
Adds description of how compilation and precompilation works.
Also, I fixed some naming in the compilaiton module to make it more consistent.

Note, that naming of some public precompilation stages changed!

Partially resolves #38 .