### PR TITLE
chore: remove "estimator" naming

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -10,7 +10,7 @@ For some quantum algorithms, the expression for their cost might depend on the i
 - using user-defined functions instead of sympy expressions
 
 
-However, all these methods introduce additional complexities which may or may not be appropriate for a given use-case. Ultimately, bartiq does not provide any native approach for dynamic definition of estimators based on circuit topologies, so users are responsible for such decision-making prior to compilation.
+However, all these methods introduce additional complexities which may or may not be appropriate for a given use-case. Ultimately, bartiq does not provide any native approach for dynamic definition of routines based on the topology, so users are responsible for such decision-making prior to compilation.
 
 
 ## Non-trivial port sizes

--- a/src/bartiq/integrations/latex.py
+++ b/src/bartiq/integrations/latex.py
@@ -48,13 +48,13 @@ def _format_object_header(routine: Routine) -> str:
 
 
 def _format_input_params(input_params: list[str]):
-    """Formats estimator input parameters to LaTeX."""
+    """Formats input parameters to LaTeX."""
     input_params = [_format_param(input_param) for input_param in input_params]
     return _format_section_one_line("Input parameters", input_params)
 
 
 def _format_linked_params(linked_params):
-    """Formats estimator inherited parameters to LaTeX."""
+    """Formats linked parameters to LaTeX."""
     lines = []
     for param, children_links in linked_params.items():
         key = _format_param_math(param)
@@ -81,7 +81,7 @@ def _format_port_sizes(ports, label):
 
 
 def _format_local_variables(local_variables):
-    """Formats estimator local parameters to LaTeX."""
+    """Formats routine's local variables to LaTeX."""
     lines = []
     for variable in local_variables:
         assignment, expression = split_equation(variable)
@@ -180,7 +180,7 @@ def _format_resources(routine: Routine, show_non_root_resources: bool):
 
 
 def _get_resources_lines(resources, path=None):
-    """Formats estimator costs to LaTeX."""
+    """Formats resources to LaTeX."""
     lines = []
     for resource in resources.values():
         if path is None:

--- a/tests/compilation/test_compile.py
+++ b/tests/compilation/test_compile.py
@@ -277,7 +277,7 @@ COMPILE_ERRORS_TEST_CASES = [
         "Can only pull in size parameters from the root routine, but source is a non-root non-leaf routine; "
         "attempted to pull a.#in_0 in to a.b.#in_0.",
     ),
-    # Attempt to assign estimators with inconsistent constant register sizes
+    # Attempt to assign inconsistent constant register sizes
     (
         Routine(
             name="root",
@@ -335,7 +335,7 @@ COMPILE_ERRORS_TEST_CASES = [
         "Input registers cannot be constant-sized; "
         "attempted to merge register size a.#out_foo = a.M + a.N with b.#in_bar.1",
     ),
-    # Attempt to connect a two different sizes to an estimator which has both inputs of the same size
+    # Attempt to connect two different sizes to routine which has both inputs of the same size
     (
         Routine(
             name="root",

--- a/tests/compilation/test_symbolic_function.py
+++ b/tests/compilation/test_symbolic_function.py
@@ -242,15 +242,15 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize("estimator, expected_function", TO_SYMBOLIC_FUNCTION_TEST_CASES)
-def test_to_symbolic_function(estimator, expected_function, backend):
+@pytest.mark.parametrize("routine, expected_function", TO_SYMBOLIC_FUNCTION_TEST_CASES)
+def test_to_symbolic_function(routine, expected_function, backend):
     expected_function = SymbolicFunction.from_str(*expected_function, backend)
 
-    assert to_symbolic_function(estimator, backend) == expected_function
+    assert to_symbolic_function(routine, backend) == expected_function
 
 
 @pytest.mark.parametrize(
-    "estimator, expected_error",
+    "routine, expected_error",
     [
         # Non-trivial expressions for input register sizes
         (
@@ -279,12 +279,12 @@ def test_to_symbolic_function(estimator, expected_function, backend):
         ),
     ],
 )
-def test_to_symbolic_function_errors(estimator, expected_error, backend):
+def test_to_symbolic_function_errors(routine, expected_error, backend):
     with pytest.raises(BartiqCompilationError, match=expected_error):
-        to_symbolic_function(estimator, backend)
+        to_symbolic_function(routine, backend)
 
 
-TO_ESTIMATOR_TEST_CASES = [
+UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
     # Null case
     (
         _make_routine(),
@@ -383,7 +383,7 @@ TO_ESTIMATOR_TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize("routine, function, expected_routine", TO_ESTIMATOR_TEST_CASES)
+@pytest.mark.parametrize("routine, function, expected_routine", UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES)
 def test_update_routine_with_symbolic_function(routine, function, expected_routine, backend):
     function = SymbolicFunction.from_str(*function, backend)
 
@@ -407,7 +407,7 @@ def test_update_routine_with_symbolic_function(routine, function, expected_routi
         ),
     ],
 )
-def test_to_estimator_fails(routine, function, expected_error, backend):
+def test_update_routine_with_symbolic_function_fails(routine, function, expected_error, backend):
     function = SymbolicFunction.from_str(*function, backend)
     with pytest.raises(BartiqCompilationError, match=expected_error):
         update_routine_with_symbolic_function(routine, function)

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for Estimators' LaTeX rendering."""
 
 import pytest
 


### PR DESCRIPTION
I noticed we use stale terminology in a couple of places, this PR just updates that.