### PR TITLE
53 fix handling root name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.xml
 .benchmarks/
 .ipynb_checkpoints/
 .cache
+.vscode

--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -338,7 +338,11 @@ class Routine(BaseModel):
                 raise ValueError("Ancestor not found.") from e
 
     def absolute_path(self, exclude_root_name: bool = False) -> str:
-        """Returns a path from root."""
+        """Returns a path from root.
+
+        Args:
+            exclude_root_name: If true, excludes name of root from the path. Default: False
+        """
         if self.parent is None and exclude_root_name:
             return ""
         else:
@@ -393,7 +397,11 @@ class Port(BaseModel):
         return f"{self.__class__.__name__}({parent_name}.#{self.name}, size={size_value}, {self.direction})"
 
     def absolute_path(self, exclude_root_name: bool = False) -> str:
-        """Returns a path from root."""
+        """Returns a path from root.
+
+        Args:
+            exclude_root_name: If true, excludes name of root from the path. Default: False
+        """
         assert self.parent is not None
         if self.parent.absolute_path(exclude_root_name=exclude_root_name) == "":
             return f"#{self.name}"

--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -312,11 +312,12 @@ class Routine(BaseModel):
         else:
             return _find_descendant(selector, self.children)
 
-    def relative_path_from(self, ancestor: Optional[Routine]) -> str:
+    def relative_path_from(self, ancestor: Optional[Routine], exclude_root_name: bool = False) -> str:
         """Return relative path to the ancestor.
 
         Args:
             ancestor: Ancestor from which a relative path to self should be found.
+            exclude_root_name: if True, removes the name of the root from the relative path, if it is present.
 
         Returns:
             selector s such that ancestor.find_descendant(s) is self.
@@ -324,18 +325,33 @@ class Routine(BaseModel):
         Raises:
             ValueError: If ancestor is not, in fact, an ancestor of self.
         """
+
+        # For root node return an empty string
+        if self.parent is None and ancestor is None and exclude_root_name:
+            return ""
         if self.parent is ancestor:
             return self.name
         else:
             try:
-                return f"{self.parent.relative_path_from(ancestor)}.{self.name}"  # type: ignore
+                return f"{self.parent.relative_path_from(ancestor, exclude_root_name=exclude_root_name)}.{self.name}"  # type: ignore
             except (ValueError, AttributeError) as e:
                 raise ValueError("Ancestor not found.") from e
 
-    @property
-    def absolute_path(self) -> str:
+    def absolute_path(self, exclude_root_name: bool = False) -> str:
         """Returns a path from root."""
-        return self.relative_path_from(None).removeprefix(".")
+        return self.relative_path_from(None, exclude_root_name=exclude_root_name).removeprefix(".")
+
+    def absolute_path_without_root(self, exclude_root_name: bool = True) -> str:
+        """Returns a path from root."""
+        if self.parent is None:
+            return ""
+        else:
+            return self.relative_path_from(None, exclude_root_name=exclude_root_name).removeprefix(".")
+        path = self.relative_path_from(None).removeprefix(".")
+        if "." not in path:
+            return ""
+        else:
+            return self.relative_path_from(None).removeprefix(".")
 
     def _repr_markdown_(self):
         from .integrations.latex import routine_to_latex
@@ -385,14 +401,21 @@ class Port(BaseModel):
         size_value = "None" if self.size is None else f'"{self.size}"'
         return f"{self.__class__.__name__}({parent_name}.#{self.name}, size={size_value}, {self.direction})"
 
-    @property
-    def absolute_path(self) -> str:
+    def absolute_path(self, exclude_root_name: bool = False) -> str:
         """Returns a path from root."""
         assert self.parent is not None
-        if self.parent.absolute_path == "":
+        if self.parent.absolute_path(exclude_root_name=exclude_root_name) == "":
             return f"#{self.name}"
         else:
-            return f"{self.parent.absolute_path}.#{self.name}"
+            return f"{self.parent.absolute_path(exclude_root_name=exclude_root_name)}.#{self.name}"
+
+    def absolute_path_without_root(self, exclude_root_name: bool = True) -> str:
+        """Returns a path from root."""
+        assert self.parent is not None
+        if self.parent.absolute_path_without_root(exclude_root_name=exclude_root_name) == "":
+            return f"#{self.name}"
+        else:
+            return f"{self.parent.absolute_path_without_root(exclude_root_name=exclude_root_name)}.#{self.name}"
 
 
 class Connection(BaseModel):

--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -333,25 +333,16 @@ class Routine(BaseModel):
             return self.name
         else:
             try:
-                return f"{self.parent.relative_path_from(ancestor, exclude_root_name=exclude_root_name)}.{self.name}"  # type: ignore
+                return f"{self.parent.relative_path_from(ancestor, exclude_root_name=exclude_root_name)}.{self.name}"  # type: ignore # noqa: E501
             except (ValueError, AttributeError) as e:
                 raise ValueError("Ancestor not found.") from e
 
     def absolute_path(self, exclude_root_name: bool = False) -> str:
         """Returns a path from root."""
-        return self.relative_path_from(None, exclude_root_name=exclude_root_name).removeprefix(".")
-
-    def absolute_path_without_root(self, exclude_root_name: bool = True) -> str:
-        """Returns a path from root."""
-        if self.parent is None:
+        if self.parent is None and exclude_root_name:
             return ""
         else:
             return self.relative_path_from(None, exclude_root_name=exclude_root_name).removeprefix(".")
-        path = self.relative_path_from(None).removeprefix(".")
-        if "." not in path:
-            return ""
-        else:
-            return self.relative_path_from(None).removeprefix(".")
 
     def _repr_markdown_(self):
         from .integrations.latex import routine_to_latex
@@ -408,14 +399,6 @@ class Port(BaseModel):
             return f"#{self.name}"
         else:
             return f"{self.parent.absolute_path(exclude_root_name=exclude_root_name)}.#{self.name}"
-
-    def absolute_path_without_root(self, exclude_root_name: bool = True) -> str:
-        """Returns a path from root."""
-        assert self.parent is not None
-        if self.parent.absolute_path_without_root(exclude_root_name=exclude_root_name) == "":
-            return f"#{self.name}"
-        else:
-            return f"{self.parent.absolute_path_without_root(exclude_root_name=exclude_root_name)}.#{self.name}"
 
 
 class Connection(BaseModel):

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -87,8 +87,6 @@ def _compile_routine(
     global_functions: Optional[list[str]] = None,
     functions_map: Optional[FunctionsMap] = None,
 ):
-    # root_name = routine.name
-    # routine.name = ""
     precompile(routine, precompilation_stages=precompilation_stages, backend=backend)
 
     # NOTE: This step must be completed BEFORE we start to compile the functions, as parents must be allowed to
@@ -96,7 +94,6 @@ def _compile_routine(
     routine_with_functions = _add_function_to_routine(routine, global_functions, backend)
 
     compiled_routine_with_funcs = _compile_routine_with_functions(routine_with_functions, functions_map, backend)
-    # compiled_routine_with_funcs.name = root_name
 
     compiled_routine = compiled_routine_with_funcs.to_routine()
     compiled_routine = _remove_children_costs(compiled_routine)
@@ -124,7 +121,9 @@ def _map_routine_to_function(
     local_function = to_symbolic_function(routine, backend)
 
     # Updates the functions' namespace to a path-prefixed global
-    global_function = _add_function_namespace(local_function, routine.absolute_path_without_root(), global_functions)
+    global_function = _add_function_namespace(
+        local_function, routine.absolute_path(exclude_root_name=True), global_functions
+    )
     # Pull in and push out register sizes
     # NOTE: Non-leaf routines shouldn't have input or output register sizes defined
     # (since they are dependent upon the size of some other routines's register), so skip this step for them.
@@ -200,9 +199,11 @@ def _pull_in_input_register_size_param(
     if not source_parent.is_root:
         raise BartiqCompilationError(
             "Can only pull in size parameters from the root routine, but source is a non-root non-leaf routine; "
-            f"attempted to pull {source_port.absolute_path_without_root()} in to {input_port.absolute_path_without_root()}."
-            f"This indicates that {source_port.absolute_path_without_root()} terminates a connection on a non-leaf routine, "
-            f"which is an invalid topology. Please connect {source_port.absolute_path_without_root()} to a leaf port."
+            f"attempted to pull {source_port.absolute_path(exclude_root_name=True)} in to "
+            f"{input_port.absolute_path(exclude_root_name=True)}."
+            f"This indicates that {source_port.absolute_path(exclude_root_name=True)} terminates a connection "
+            f"on a non-leaf routine, which is an invalid topology. "
+            f"Please connect {source_port.absolute_path(exclude_root_name=True)} to a leaf port."
         )
 
     root_input_register_size = source_parent.input_ports[source_port.name].size
@@ -211,15 +212,15 @@ def _pull_in_input_register_size_param(
     if is_constant_int(root_input_register_size):
         assert isinstance(root_input_register_size, (int, str))
         new_function = set_input_port_size_to_constant_value(
-            function, input_port.absolute_path_without_root(), int(root_input_register_size), backend
+            function, input_port.absolute_path(exclude_root_name=True), int(root_input_register_size), backend
         )
         return new_function
 
     # If the root input is of variable size, then we will rename the parameter with the root parameter
     elif is_single_parameter(root_input_register_size):
-        root_param = join_paths(source_port.absolute_path_without_root(), str(root_input_register_size))
+        root_param = join_paths(source_port.absolute_path(exclude_root_name=True), str(root_input_register_size))
         param = str(input_port.size)
-        leaf_param = join_paths(input_port.absolute_path_without_root(), param)
+        leaf_param = join_paths(input_port.absolute_path(exclude_root_name=True), param)
         if is_constant_int(param):
             raise BartiqCompilationError(
                 "Input registers cannot be constant-sized; "
@@ -316,7 +317,7 @@ def _push_out_output_register_size_params(
 
     new_function = function
     for port in routine.output_ports.values():
-        output = port.absolute_path_without_root()
+        output = port.absolute_path(exclude_root_name=True)
         source_register_size_variable = function.outputs[output]
         target_port = get_port_target(port)
         target_routine = target_port.parent
@@ -342,7 +343,7 @@ def _push_out_output_register_size_params(
                     "Input registers cannot be constant-sized; "
                     f"attempted to merge register size {source_register_size_variable} with {target_param}"
                 )
-            new_function = rename_variables(new_function, {port.absolute_path_without_root(): target_param})
+            new_function = rename_variables(new_function, {port.absolute_path(exclude_root_name=True): target_param})
 
     # Return function with renamed parameters
     return new_function
@@ -357,20 +358,20 @@ def _resolve_target_param(target: Port) -> str:
         assert (
             target_routine.is_root
         ), "Shouldn't ever find non-root non-leaf target. Most likely ports are connected incorrectly"
-        return target.absolute_path_without_root()
+        return target.absolute_path(exclude_root_name=True)
 
     if target.size is None or target.size == "":
         raise BartiqCompilationError(
-            f"No size found for input register {target.name} in {target.absolute_path_without_root()}"
+            f"No size found for input register {target.name} in {target.absolute_path(exclude_root_name=True)}"
         )
     target_register_param = str(target.size)
-    return join_paths(target.absolute_path_without_root(), target_register_param)
+    return join_paths(target.absolute_path(exclude_root_name=True), target_register_param)
 
 
 def _pass_on_inherited_params(routine: RoutineWithFunction[T_expr]) -> None:
     """Overwrites childrens' parameters."""
     for local_ancestor_param, links in routine.linked_params.items():
-        global_ancestor_param = join_paths(routine.absolute_path_without_root(), local_ancestor_param)
+        global_ancestor_param = join_paths(routine.absolute_path(exclude_root_name=True), local_ancestor_param)
         for inheritor_path, param_name in links:
             if "." in inheritor_path:
                 raise BartiqCompilationError(
@@ -380,7 +381,7 @@ def _pass_on_inherited_params(routine: RoutineWithFunction[T_expr]) -> None:
                 )
             inheritor = routine.children[inheritor_path]
             # Define ancestor-to-inheritor parameter map
-            param_map = {join_paths(inheritor.absolute_path_without_root(), param_name): global_ancestor_param}
+            param_map = {join_paths(inheritor.absolute_path(exclude_root_name=True), param_name): global_ancestor_param}
 
             # Apply the renaming to the inheritor routine as well as all descendent routines.
             # This is needed because inheritance happens from the bottom up, so if a subroutine of the current
@@ -442,7 +443,7 @@ def _compile_function_to_routine_leaf_non_root(
     local_function = _undo_pull_in_input_register_size_params_leaf(local_function, routine)
 
     # Remove the global path namespace to make routine ignorant of higher structure
-    namespace = routine.absolute_path_without_root()
+    namespace = routine.absolute_path(exclude_root_name=True)
     local_function = _remove_function_namespace(local_function, namespace)
 
     return local_function
@@ -493,7 +494,7 @@ def _compile_function_to_routine_non_leaf_non_root(
     new_function = _undo_push_out_output_register_size_params(new_function, routine)
 
     # Next, remove any global parameter namespaces to ensure the function is locally consistent.
-    namespace = routine.absolute_path_without_root()
+    namespace = routine.absolute_path(exclude_root_name=True)
     new_function = _remove_function_namespace(new_function, namespace)
 
     # Lastly, go find the sizes of any constant-sized registers which weren't included in the compilation
@@ -513,7 +514,7 @@ def _remove_constant_register_sizes_non_leaf_non_root(
         # Case 1: It's a constant register size
         if name.startswith("#") and output_variable.is_constant_int:
             # Case 1.1: It's a constant register size for the current routine => keep
-            if path == routine.absolute_path_without_root():
+            if path == routine.absolute_path(exclude_root_name=True):
                 new_outputs[output_symbol] = output_variable
 
             # Case 1.2: It's a constant register size for another routine => ignore
@@ -543,8 +544,8 @@ def _undo_pull_in_input_register_size_params_leaf(
 
         source_register = source_port.name
         source_param = str(source_parent.input_ports[source_register].size)
-        child_param = join_paths(source_port.absolute_path_without_root(), source_param)
-        parent_param = join_paths(input_port.absolute_path_without_root(), source_param)
+        child_param = join_paths(source_port.absolute_path(exclude_root_name=True), source_param)
+        parent_param = join_paths(input_port.absolute_path(exclude_root_name=True), source_param)
         param_map[child_param] = parent_param
 
     return rename_variables(function, param_map)
@@ -574,11 +575,11 @@ def _undo_pull_in_input_register_size_params_non_leaf(
         param = str(port.size)
 
         if is_constant_int(param):
-            child_param = port.absolute_path_without_root()
-            parent_param = input_port.absolute_path_without_root()
+            child_param = port.absolute_path(exclude_root_name=True)
+            parent_param = input_port.absolute_path(exclude_root_name=True)
         elif is_single_parameter(param):
-            child_param = join_paths(port.absolute_path_without_root(), param)
-            parent_param = join_paths(input_port.absolute_path_without_root(), param)
+            child_param = join_paths(port.absolute_path(exclude_root_name=True), param)
+            parent_param = join_paths(input_port.absolute_path(exclude_root_name=True), param)
         else:
             raise ValueError("param should be either integer or a single symbol, got {param}.")
 
@@ -602,8 +603,10 @@ def _undo_push_out_output_register_size_params(
     for source in routine.output_ports.values():
         target = get_port_target(source)
         assert target.parent is not None
-        new_param = _resolve_target_param(target) if target.parent.is_leaf else target.absolute_path_without_root()
-        param_map[new_param] = source.absolute_path_without_root()
+        new_param = (
+            _resolve_target_param(target) if target.parent.is_leaf else target.absolute_path(exclude_root_name=True)
+        )
+        param_map[new_param] = source.absolute_path(exclude_root_name=True)
 
     # Return function with renamed parameters
     return rename_variables(function, param_map)
@@ -670,7 +673,7 @@ def _get_internal_port_endpoint(port: Port) -> Port:
     if port.direction == "output":
         endpoint = get_port_source(port)
 
-    assert endpoint is not None, f"Expected {port.absolute_path_without_root()} to have an internal endpoint."
+    assert endpoint is not None, f"Expected {port.absolute_path(exclude_root_name=True)} to have an internal endpoint."
     return endpoint
 
 

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -87,8 +87,8 @@ def _compile_routine(
     global_functions: Optional[list[str]] = None,
     functions_map: Optional[FunctionsMap] = None,
 ):
-    root_name = routine.name
-    routine.name = ""
+    # root_name = routine.name
+    # routine.name = ""
     precompile(routine, precompilation_stages=precompilation_stages, backend=backend)
 
     # NOTE: This step must be completed BEFORE we start to compile the functions, as parents must be allowed to
@@ -96,7 +96,7 @@ def _compile_routine(
     routine_with_functions = _add_function_to_routine(routine, global_functions, backend)
 
     compiled_routine_with_funcs = _compile_routine_with_functions(routine_with_functions, functions_map, backend)
-    compiled_routine_with_funcs.name = root_name
+    # compiled_routine_with_funcs.name = root_name
 
     compiled_routine = compiled_routine_with_funcs.to_routine()
     compiled_routine = _remove_children_costs(compiled_routine)
@@ -124,8 +124,7 @@ def _map_routine_to_function(
     local_function = to_symbolic_function(routine, backend)
 
     # Updates the functions' namespace to a path-prefixed global
-    global_function = _add_function_namespace(local_function, routine.absolute_path, global_functions)
-
+    global_function = _add_function_namespace(local_function, routine.absolute_path_without_root(), global_functions)
     # Pull in and push out register sizes
     # NOTE: Non-leaf routines shouldn't have input or output register sizes defined
     # (since they are dependent upon the size of some other routines's register), so skip this step for them.
@@ -201,9 +200,9 @@ def _pull_in_input_register_size_param(
     if not source_parent.is_root:
         raise BartiqCompilationError(
             "Can only pull in size parameters from the root routine, but source is a non-root non-leaf routine; "
-            f"attempted to pull {source_port.absolute_path} in to {input_port.absolute_path}."
-            f"This indicates that {source_port.absolute_path} terminates a connection on a non-leaf routine, "
-            f"which is an invalid topology. Please connect {source_port.absolute_path} to a leaf port."
+            f"attempted to pull {source_port.absolute_path_without_root()} in to {input_port.absolute_path_without_root()}."
+            f"This indicates that {source_port.absolute_path_without_root()} terminates a connection on a non-leaf routine, "
+            f"which is an invalid topology. Please connect {source_port.absolute_path_without_root()} to a leaf port."
         )
 
     root_input_register_size = source_parent.input_ports[source_port.name].size
@@ -212,15 +211,15 @@ def _pull_in_input_register_size_param(
     if is_constant_int(root_input_register_size):
         assert isinstance(root_input_register_size, (int, str))
         new_function = set_input_port_size_to_constant_value(
-            function, input_port.absolute_path, int(root_input_register_size), backend
+            function, input_port.absolute_path_without_root(), int(root_input_register_size), backend
         )
         return new_function
 
     # If the root input is of variable size, then we will rename the parameter with the root parameter
     elif is_single_parameter(root_input_register_size):
-        root_param = join_paths(source_port.absolute_path, str(root_input_register_size))
+        root_param = join_paths(source_port.absolute_path_without_root(), str(root_input_register_size))
         param = str(input_port.size)
-        leaf_param = join_paths(input_port.absolute_path, param)
+        leaf_param = join_paths(input_port.absolute_path_without_root(), param)
         if is_constant_int(param):
             raise BartiqCompilationError(
                 "Input registers cannot be constant-sized; "
@@ -317,7 +316,7 @@ def _push_out_output_register_size_params(
 
     new_function = function
     for port in routine.output_ports.values():
-        output = port.absolute_path
+        output = port.absolute_path_without_root()
         source_register_size_variable = function.outputs[output]
         target_port = get_port_target(port)
         target_routine = target_port.parent
@@ -343,7 +342,7 @@ def _push_out_output_register_size_params(
                     "Input registers cannot be constant-sized; "
                     f"attempted to merge register size {source_register_size_variable} with {target_param}"
                 )
-            new_function = rename_variables(new_function, {port.absolute_path: target_param})
+            new_function = rename_variables(new_function, {port.absolute_path_without_root(): target_param})
 
     # Return function with renamed parameters
     return new_function
@@ -358,18 +357,20 @@ def _resolve_target_param(target: Port) -> str:
         assert (
             target_routine.is_root
         ), "Shouldn't ever find non-root non-leaf target. Most likely ports are connected incorrectly"
-        return target.absolute_path
+        return target.absolute_path_without_root()
 
     if target.size is None or target.size == "":
-        raise BartiqCompilationError(f"No size found for input register {target.name} in {target.absolute_path}")
+        raise BartiqCompilationError(
+            f"No size found for input register {target.name} in {target.absolute_path_without_root()}"
+        )
     target_register_param = str(target.size)
-    return join_paths(target.absolute_path, target_register_param)
+    return join_paths(target.absolute_path_without_root(), target_register_param)
 
 
 def _pass_on_inherited_params(routine: RoutineWithFunction[T_expr]) -> None:
     """Overwrites childrens' parameters."""
     for local_ancestor_param, links in routine.linked_params.items():
-        global_ancestor_param = join_paths(routine.absolute_path, local_ancestor_param)
+        global_ancestor_param = join_paths(routine.absolute_path_without_root(), local_ancestor_param)
         for inheritor_path, param_name in links:
             if "." in inheritor_path:
                 raise BartiqCompilationError(
@@ -379,7 +380,7 @@ def _pass_on_inherited_params(routine: RoutineWithFunction[T_expr]) -> None:
                 )
             inheritor = routine.children[inheritor_path]
             # Define ancestor-to-inheritor parameter map
-            param_map = {join_paths(inheritor.absolute_path, param_name): global_ancestor_param}
+            param_map = {join_paths(inheritor.absolute_path_without_root(), param_name): global_ancestor_param}
 
             # Apply the renaming to the inheritor routine as well as all descendent routines.
             # This is needed because inheritance happens from the bottom up, so if a subroutine of the current
@@ -441,7 +442,7 @@ def _compile_function_to_routine_leaf_non_root(
     local_function = _undo_pull_in_input_register_size_params_leaf(local_function, routine)
 
     # Remove the global path namespace to make routine ignorant of higher structure
-    namespace = routine.absolute_path
+    namespace = routine.absolute_path_without_root()
     local_function = _remove_function_namespace(local_function, namespace)
 
     return local_function
@@ -492,7 +493,7 @@ def _compile_function_to_routine_non_leaf_non_root(
     new_function = _undo_push_out_output_register_size_params(new_function, routine)
 
     # Next, remove any global parameter namespaces to ensure the function is locally consistent.
-    namespace = routine.absolute_path
+    namespace = routine.absolute_path_without_root()
     new_function = _remove_function_namespace(new_function, namespace)
 
     # Lastly, go find the sizes of any constant-sized registers which weren't included in the compilation
@@ -512,7 +513,7 @@ def _remove_constant_register_sizes_non_leaf_non_root(
         # Case 1: It's a constant register size
         if name.startswith("#") and output_variable.is_constant_int:
             # Case 1.1: It's a constant register size for the current routine => keep
-            if path == routine.absolute_path:
+            if path == routine.absolute_path_without_root():
                 new_outputs[output_symbol] = output_variable
 
             # Case 1.2: It's a constant register size for another routine => ignore
@@ -542,8 +543,8 @@ def _undo_pull_in_input_register_size_params_leaf(
 
         source_register = source_port.name
         source_param = str(source_parent.input_ports[source_register].size)
-        child_param = join_paths(source_port.absolute_path, source_param)
-        parent_param = join_paths(input_port.absolute_path, source_param)
+        child_param = join_paths(source_port.absolute_path_without_root(), source_param)
+        parent_param = join_paths(input_port.absolute_path_without_root(), source_param)
         param_map[child_param] = parent_param
 
     return rename_variables(function, param_map)
@@ -573,11 +574,11 @@ def _undo_pull_in_input_register_size_params_non_leaf(
         param = str(port.size)
 
         if is_constant_int(param):
-            child_param = port.absolute_path
-            parent_param = input_port.absolute_path
+            child_param = port.absolute_path_without_root()
+            parent_param = input_port.absolute_path_without_root()
         elif is_single_parameter(param):
-            child_param = join_paths(port.absolute_path, param)
-            parent_param = join_paths(input_port.absolute_path, param)
+            child_param = join_paths(port.absolute_path_without_root(), param)
+            parent_param = join_paths(input_port.absolute_path_without_root(), param)
         else:
             raise ValueError("param should be either integer or a single symbol, got {param}.")
 
@@ -601,8 +602,8 @@ def _undo_push_out_output_register_size_params(
     for source in routine.output_ports.values():
         target = get_port_target(source)
         assert target.parent is not None
-        new_param = _resolve_target_param(target) if target.parent.is_leaf else target.absolute_path
-        param_map[new_param] = source.absolute_path
+        new_param = _resolve_target_param(target) if target.parent.is_leaf else target.absolute_path_without_root()
+        param_map[new_param] = source.absolute_path_without_root()
 
     # Return function with renamed parameters
     return rename_variables(function, param_map)
@@ -669,7 +670,7 @@ def _get_internal_port_endpoint(port: Port) -> Port:
     if port.direction == "output":
         endpoint = get_port_source(port)
 
-    assert endpoint is not None, f"Expected {port.absolute_path} to have an internal endpoint."
+    assert endpoint is not None, f"Expected {port.absolute_path_without_root()} to have an internal endpoint."
     return endpoint
 
 
@@ -680,6 +681,7 @@ def _split_local_path(path: str) -> tuple[str, str]:
 
 
 def _remove_children_costs(routine: Routine) -> Routine:
+    # NOTE: we probably should not be adding children costs in the first place, rather than removing it.
     for subroutine in routine.walk():
         subroutine.resources = {name: res for name, res in subroutine.resources.items() if "." not in name}
     return routine

--- a/src/bartiq/compilation/_evaluate.py
+++ b/src/bartiq/compilation/_evaluate.py
@@ -177,8 +177,8 @@ def _evaluate_over_assignment(
             subroutine_assignments.append(assignment)
 
         # Check for any register size assignments that have been propagated from upstream ports
-        if subroutine.absolute_path in register_sizes:
-            subroutine_assignments.extend(register_sizes.pop(subroutine.absolute_path))
+        if subroutine.absolute_path() in register_sizes:
+            subroutine_assignments.extend(register_sizes.pop(subroutine.absolute_path()))
 
         # Compute the new routine
         evaluated_routine = _evaluate_routine(subroutine, subroutine_assignments, backend, functions_map)
@@ -206,7 +206,7 @@ def _get_downstream_register_size_assignments(source_port: Port, value: Number) 
         variable = str(target_port.size)
         local_assignment = _RegisterSizeAssignment(target_port.direction, target_port.name, variable, value)
         assert target_port.parent is not None
-        register_sizes[target_port.parent.absolute_path].append(local_assignment)
+        register_sizes[target_port.parent.absolute_path()].append(local_assignment)
 
     return register_sizes
 

--- a/src/bartiq/compilation/_symbolic_function.py
+++ b/src/bartiq/compilation/_symbolic_function.py
@@ -713,18 +713,8 @@ def update_routine_with_symbolic_function(routine: Routine, function: SymbolicFu
             routine.resources[lhs].value = rhs
         else:
             raw_name = lhs.split(".")[-1]
-            if raw_name in routine.resources:
-                type = routine.resources[raw_name].type
-            else:
-                # NOTE: This logic handles the case where we add children's costs to the parent.
-                # I think in future we want to get rid of this, but it is necessary for backward compatibility reasons.
-                for subroutine in routine.walk():
-                    if raw_name in subroutine.resources:
-                        type = subroutine.resources[raw_name].type
-                        break
-                else:
-                    type = ResourceType.other
-            routine.resources[lhs] = Resource(name=lhs, value=rhs, parent=routine, type=type)
+            type = ResourceType.other
+            routine.resources[lhs] = Resource(name=raw_name, value=rhs, parent=routine, type=type)
 
 
 def _parse_function_inputs(function):

--- a/tests/compilation/data/compile_test_data.yaml
+++ b/tests/compilation/data/compile_test_data.yaml
@@ -350,7 +350,7 @@
             y_bb}
     input_params: [x_aa, x_ab, x_ba, x_bb, y_aa, y_ab, y_ba, y_bb]
 # Children and grandchildren, resources dependent on children, with ports, with input params and params linking
-- - name: ''
+- - name: root
     type: null
     ports:
       foo:
@@ -490,7 +490,7 @@
       - [b.b, x]
       y_bb:
       - [b.b, y]
-  - name: ''
+  - name: root
     type: null
     ports:
       foo:
@@ -632,7 +632,7 @@
             y_ba + y_bb}
     input_params: [x_aa, x_ab, x_ba, x_bb, y_aa, y_ab, y_ba, y_bb]
 # Children and grandchildren, resources dependent on children, no ports, local variables in leaves
-- - name: ''
+- - name: root
     type: null
     children:
       a:
@@ -698,7 +698,7 @@
         name: z
         type: other
         value: {type: str, value: a.z + b.z}
-  - name: ''
+  - name: root
     type: null
     children:
       a:
@@ -768,7 +768,7 @@
   # This is a legacy test case which used to verify if children are compiled in
   # topological rather than definition order. This is of little relevance now,
   # as children are stored as dictionaries rather than list.
-- - name: ''
+- - name: root
     type: null
     children:
       b:
@@ -789,7 +789,7 @@
             size: {type: str, value: '1'}
     connections:
     - {source: a.out_0, target: b.in_0}
-  - name: ''
+  - name: root
     type: null
     children:
       b:
@@ -1067,7 +1067,7 @@
         type: other
         value: {type: str, value: '4'}
 # Constant register size comes from non-root
-- - name: ''
+- - name: root
     type: null
     ports:
       out_0: {name: out_0, direction: output, size: null}
@@ -1095,7 +1095,7 @@
     connections:
     - {source: a.out_0, target: b.in_0}
     - {source: b.out_0, target: out_0}
-  - name: ''
+  - name: root
     type: null
     ports:
       out_0:
@@ -1127,7 +1127,7 @@
     - {source: a.out_0, target: b.in_0}
     - {source: b.out_0, target: out_0}
 # Parent's and child's ports are connected and the port sizes are defined in both cases (not None)
-- - name: ''
+- - name: root
     type: null
     ports:
       in_0:
@@ -1179,7 +1179,7 @@
         name: N
         type: other
         value: {type: str, value: a.A}
-  - name: ''
+  - name: root
     type: null
     ports:
       in_0:

--- a/tests/compilation/data/evaluate_test_data.yaml
+++ b/tests/compilation/data/evaluate_test_data.yaml
@@ -1,9 +1,11 @@
 # Null case
-- - {name: '', type: null}
+- - name: 'root'
+    type: null
   - []
-  - {name: '', type: null}
+  - name: 'root'
+    type: null
 # Resource defined as a function of a single input param
-- - name: ''
+- - name: 'root'
     type: null
     input_params: [x]
     resources:
@@ -12,7 +14,7 @@
         type: other
         value: {type: str, value: log2(x)}
   - [x=120]
-  - name: ''
+  - name: 'root'
     type: null
     resources:
       Q:
@@ -20,7 +22,7 @@
         type: other
         value: {type: str, value: '6.90689059560852'}
 # Port size is a function of input params, value of one param is provided for evaluation
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -38,7 +40,7 @@
         value: {type: str, value: x * y}
     input_params: [x, y]
   - [x = 42]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       out_0:
@@ -56,7 +58,7 @@
         value: {type: str, value: 42*y}
     input_params: [y]
 # Simple root-only case (both input param and register size is set, but other params remain)
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -78,7 +80,7 @@
         value: {type: str, value: x * y * N * M}
     input_params: [x, y]
   - [x = 2, N = 3]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -100,7 +102,7 @@
         value: {type: str, value: 6*M*y}
     input_params: [y]
 # Simple root-only case (both input param and register size is set and share the name, but other params remain)
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -122,7 +124,7 @@
         value: {type: str, value: N * y * N * M}
     input_params: [N, y]
   - [N = 3]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -144,7 +146,7 @@
         value: {type: str, value: 9*M*y}
     input_params: [y]
 # Circuit with single child, register sizes being propagated.
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -193,7 +195,7 @@
         value: {type: str, value: x * y * z * N * M}
     input_params: [x, y, z]
   - [x = 2, N = 3, z = 4]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -242,7 +244,7 @@
         value: {type: str, value: 24*M*y}
     input_params: [y]
 # Circuit with child and grandchild, registers being propagated
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -332,7 +334,7 @@
         value: {type: str, value: z * z * x * y * N * M}
     input_params: [x, y, z]
   - [x = 2, N = 3, z = 4]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -422,7 +424,7 @@
         value: {type: str, value: 96*M*y}
     input_params: [y]
 # Chain of components (root -> a -> b -> c -> root), register sizes are propagated
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -500,7 +502,7 @@
         value: {type: str, value: N * x * y * z}
     input_params: [x, y, z]
   - [x = 2, N = 3, z = 4]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -578,7 +580,7 @@
 # Case with no root inputs or outputs
 # NOTE: because both a_0 and a_1 depend on x, this tests the case when a component requires multiple input register
 # size updates for a single initial parameter assignment (i.e. x).
-- - name: ''
+- - name: 'root'
     type: null
     children:
       a_0:
@@ -621,7 +623,7 @@
     - {source: a_1.out_0, target: b.in_1}
     input_params: [x]
   - [x = 2]
-  - name: ''
+  - name: 'root'
     type: null
     children:
       a_0:
@@ -661,7 +663,7 @@
     - {source: a_0.out_0, target: b.in_0}
     - {source: a_1.out_0, target: b.in_1}
 # Check that expressions are simplified (for input param assignment)
-- - name: ''
+- - name: 'root'
     type: null
     resources:
       Q:
@@ -670,7 +672,7 @@
         value: {type: str, value: 'max(a, 1)'}
     input_params: [a]
   - [a = 2]
-  - name: ''
+  - name: 'root'
     type: null
     resources:
       Q:
@@ -678,7 +680,7 @@
         type: other
         value: {type: str, value: '2'}
 # Check that expressions are simplified (for input register size assignment)
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -691,7 +693,7 @@
         type: other
         value: {type: str, value: 'max(a, 1)'}
   - [a = 2]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -708,7 +710,7 @@
 # In this case, the walk order was: a.b, x, a.c, a, then the root. Hence, x was visited before all its upstream
 # components have been (i.e. a), which would cause an error.
 # This is a legacy test case.
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -779,7 +781,7 @@
     - {source: in_1, target: a.in_1}
     - {source: a.out_0, target: x.in_0}
   - [N = 1]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -850,7 +852,7 @@
     - {source: in_1, target: a.in_1}
     - {source: a.out_0, target: x.in_0}
 # Check that zero-sized registers are allowed
-- - name: ''
+- - name: 'root'
     type: null
     children:
       a:
@@ -880,7 +882,7 @@
       y:
       - [b, y]
   - [x = 1]
-  - name: ''
+  - name: 'root'
     type: null
     children:
       a:
@@ -907,7 +909,7 @@
       y:
       - [b, y]
 # Make sure evaluation doesn't fail in presence of constant size register
-- - name: ''
+- - name: 'root'
     type: null
     ports:
       in_0:
@@ -916,7 +918,7 @@
         size: {type: str, value: '1'}
     input_params: [x]
   - [x = 1]
-  - name: ''
+  - name: 'root'
     type: null
     ports:
       in_0:
@@ -937,7 +939,7 @@
     resources:
       T_gates: {name: T_gates, type: additive, value: '32'}
 # Linked params through multiple generations
-- - name: ''
+- - name: 'root'
     type: null
     input_params: [x, y]
     linked_params:
@@ -966,7 +968,7 @@
                 type: other
                 value: {type: str, value: x + y}
   - [x=10]
-  - name: ''
+  - name: 'root'
     type: null
     input_params: [y]
     linked_params:

--- a/tests/routine/test_routine.py
+++ b/tests/routine/test_routine.py
@@ -86,6 +86,17 @@ class TestFindingRelativePathFromAncestor:
             routine_d.relative_path_from(routine_c)
 
 
+class TestGettingAbsolutePath:
+    def test_gets_absolute_path_with_root_name_by_default(self):
+        child = Routine(name="child", type=None)
+        parent = Routine(name="root", children={"child": child}, type=None)
+
+        assert child.absolute_path() == "root.child"
+        assert child.absolute_path(exclude_root_name=True) == "child"
+        assert parent.absolute_path() == "root"
+        assert parent.absolute_path(exclude_root_name=True) == ""
+
+
 class TestRoutineEquality:
     def _example_routine(self):
         # The reason it is not a fixture is that we need it two times in the same

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -158,7 +158,7 @@ def _nested_routine():
 def test_get_port_source(parent_path, port_name, source_port_path, routine):
     port_parent = routine.find_descendant(parent_path)
     port = port_parent.ports[port_name]
-    assert get_port_source(port).absolute_path == source_port_path
+    assert get_port_source(port).absolute_path() == source_port_path
 
 
 @pytest.mark.parametrize(
@@ -190,4 +190,4 @@ def test_get_port_source(parent_path, port_name, source_port_path, routine):
 def test_get_port_target(parent_path, port_name, target_port_path, routine):
     port_parent = routine.find_descendant(parent_path)
     port = port_parent.ports[port_name]
-    assert get_port_target(port).absolute_path == target_port_path
+    assert get_port_target(port).absolute_path() == target_port_path


### PR DESCRIPTION
WiP version of the compilation handling proper non-empty root name.
I didn't have time to clean it up, I want to get rid of `absolute_path_without_root` and just deal with this behavior using `exclude_root_name` flag in `absolute_path`.

Closes #53 