### PR TITLE
refactor!: Make local_variables a dictionary instead of a list of strings

### DIFF
--- a/docs/tutorials/01_basic_example.ipynb
+++ b/docs/tutorials/01_basic_example.ipynb
@@ -66,6 +66,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "6e2460c7-8ec3-4157-8b92-3d8ac5ff300f",
    "metadata": {
     "ExecuteTime": {
@@ -73,6 +74,7 @@
      "start_time": "2024-06-24T20:58:18.259199Z"
     }
    },
+   "outputs": [],
    "source": [
     "my_algorithm = {\n",
     "    \"name\": \"my_algorithm\",\n",
@@ -82,9 +84,7 @@
     "        {\"name\": \"out\", \"direction\": \"output\", \"size\": None},\n",
     "    ],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 31
+   ]
   },
   {
    "cell_type": "markdown",
@@ -104,6 +104,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "591b4a88-af8c-41ec-bc07-ca0bbe576c70",
    "metadata": {
     "ExecuteTime": {
@@ -111,6 +112,7 @@
      "start_time": "2024-06-24T20:58:18.391328Z"
     }
    },
+   "outputs": [],
    "source": [
     "routine_a = {\n",
     "    \"name\": \"A\",\n",
@@ -120,9 +122,7 @@
     "        {\"name\": \"out\", \"direction\": \"output\", \"size\": \"2*n_a\"},\n",
     "    ],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 32
+   ]
   },
   {
    "cell_type": "markdown",
@@ -134,6 +134,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "76a0ed1a-0acb-489e-b2fc-40ce956b8f49",
    "metadata": {
     "ExecuteTime": {
@@ -141,6 +142,7 @@
      "start_time": "2024-06-24T20:58:18.425845Z"
     }
    },
+   "outputs": [],
    "source": [
     "routine_b = {\n",
     "    \"name\": \"B\",\n",
@@ -151,9 +153,7 @@
     "        {\"name\": \"out\", \"direction\": \"output\", \"size\": \"n_b + y\"},\n",
     "    ],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 33
+   ]
   },
   {
    "cell_type": "markdown",
@@ -174,6 +174,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "697c5cdb-abb8-4437-97e8-d3a1e4de1ca2",
    "metadata": {
     "ExecuteTime": {
@@ -181,6 +182,7 @@
      "start_time": "2024-06-24T20:58:18.521327Z"
     }
    },
+   "outputs": [],
    "source": [
     "# Define T-gate counts for routine a\n",
     "routine_a[\"input_params\"] = [\"x\"]\n",
@@ -189,9 +191,7 @@
     "# Define T-gate counts for routine b\n",
     "routine_b[\"input_params\"] = [\"y\"]\n",
     "routine_b[\"resources\"] = [{\"name\": \"T_gates\", \"type\": \"additive\", \"value\": \"n_b*ceil(log_2(n_b)) * y\"}]"
-   ],
-   "outputs": [],
-   "execution_count": 34
+   ]
   },
   {
    "cell_type": "markdown",
@@ -211,6 +211,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "3cc1dcef-a151-401b-a818-3be783aa68f9",
    "metadata": {
     "ExecuteTime": {
@@ -218,6 +219,7 @@
      "start_time": "2024-06-24T20:58:18.587847Z"
     }
    },
+   "outputs": [],
    "source": [
     "my_algorithm[\"children\"] = [routine_a, routine_b]\n",
     "my_algorithm[\"connections\"] = [\n",
@@ -227,9 +229,7 @@
     "]\n",
     "my_algorithm[\"input_params\"] = [\"z\"]\n",
     "my_algorithm[\"linked_params\"] = [{\"source\": \"z\", \"targets\": [\"A.x\", \"B.y\"]}]"
-   ],
-   "outputs": [],
-   "execution_count": 35
+   ]
   },
   {
    "cell_type": "markdown",
@@ -252,6 +252,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "ac4be2b0-f1be-46db-a42d-9f204727db7b",
    "metadata": {
     "ExecuteTime": {
@@ -259,17 +260,18 @@
      "start_time": "2024-06-24T20:58:18.637009Z"
     }
    },
+   "outputs": [],
    "source": [
     "my_algorithm_qref = {\"version\": \"v1\", \"program\": my_algorithm}"
-   ],
-   "outputs": [],
-   "execution_count": 36
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6ef92aec51534839",
    "metadata": {},
-   "source": "So, is there an intuitive way to understand what my algorithm looks like and how the resources are used in each routine? You can use the visualization tool from [`QREF`](https://github.com/PsiQ/qref) to plot the hierarchical Directed Acyclic Graph (DAG) of the algorithm you wrote."
+   "source": [
+    "So, is there an intuitive way to understand what my algorithm looks like and how the resources are used in each routine? You can use the visualization tool from [`QREF`](https://github.com/PsiQ/qref) to plot the hierarchical Directed Acyclic Graph (DAG) of the algorithm you wrote."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -288,16 +290,101 @@
    "cell_type": "markdown",
    "id": "a4f5318f14af6421",
    "metadata": {},
-   "source": "Then, run: <br>"
+   "source": [
+    "Then, run: <br>"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3464d3b49599fe1d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-24T20:58:19.585394Z",
      "start_time": "2024-06-24T20:58:18.727647Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 12.0.0 (20240704.0754)\n",
+       " -->\n",
+       "<!-- Pages: 1 -->\n",
+       "<svg width=\"381pt\" height=\"101pt\"\n",
+       " viewBox=\"0.00 0.00 381.25 101.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 97)\">\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-97 377.25,-97 377.25,4 -4,4\"/>\n",
+       "<g id=\"clust1\" class=\"cluster\">\n",
+       "<title>cluster_.my_algorithm</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M20,-8C20,-8 353.25,-8 353.25,-8 359.25,-8 365.25,-14 365.25,-20 365.25,-20 365.25,-73 365.25,-73 365.25,-79 359.25,-85 353.25,-85 353.25,-85 20,-85 20,-85 14,-85 8,-79 8,-73 8,-73 8,-20 8,-20 8,-14 14,-8 20,-8\"/>\n",
+       "<text text-anchor=\"middle\" x=\"186.62\" y=\"-67.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">my_algorithm</text>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.in&quot; -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>&quot;.my_algorithm.in&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"34\" cy=\"-35\" rx=\"18\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"34\" y=\"-31.12\" font-family=\"Times,serif\" font-size=\"10.00\">in</text>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.A&quot; -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>&quot;.my_algorithm.A&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M100,-17C100,-17 157,-17 157,-17 163,-17 169,-23 169,-29 169,-29 169,-41 169,-41 169,-47 163,-53 157,-53 157,-53 100,-53 100,-53 94,-53 88,-47 88,-41 88,-41 88,-29 88,-29 88,-23 94,-17 100,-17\"/>\n",
+       "<text text-anchor=\"middle\" x=\"100.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"113,-17.75 113,-53\"/>\n",
+       "<text text-anchor=\"middle\" x=\"125.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">A</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"138,-17.75 138,-53\"/>\n",
+       "<text text-anchor=\"middle\" x=\"153.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.in&quot;&#45;&gt;&quot;.my_algorithm.A&quot; -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>&quot;.my_algorithm.in&quot;&#45;&gt;&quot;.my_algorithm.A&quot;:in</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M52.19,-35.18C59.4,-35.25 68.11,-35.32 76.77,-35.35\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"76.48,-38.85 86.49,-35.37 76.49,-31.85 76.48,-38.85\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.out&quot; -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>&quot;.my_algorithm.out&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"339.25\" cy=\"-35\" rx=\"18\" ry=\"18\"/>\n",
+       "<text text-anchor=\"middle\" x=\"339.25\" y=\"-31.12\" font-family=\"Times,serif\" font-size=\"10.00\">out</text>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.B&quot; -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>&quot;.my_algorithm.B&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M217,-17C217,-17 273.25,-17 273.25,-17 279.25,-17 285.25,-23 285.25,-29 285.25,-29 285.25,-41 285.25,-41 285.25,-47 279.25,-53 273.25,-53 273.25,-53 217,-53 217,-53 211,-53 205,-47 205,-41 205,-41 205,-29 205,-29 205,-23 211,-17 217,-17\"/>\n",
+       "<text text-anchor=\"middle\" x=\"217.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"230,-17.75 230,-53\"/>\n",
+       "<text text-anchor=\"middle\" x=\"242.12\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">B</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"254.25,-17.75 254.25,-53\"/>\n",
+       "<text text-anchor=\"middle\" x=\"269.75\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.A&quot;&#45;&gt;&quot;.my_algorithm.B&quot; -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>&quot;.my_algorithm.A&quot;:out&#45;&gt;&quot;.my_algorithm.B&quot;:in</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M169,-35.38C180.38,-35.38 185.68,-35.38 193.55,-35.38\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"193.49,-38.88 203.49,-35.38 193.49,-31.88 193.49,-38.88\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.my_algorithm.B&quot;&#45;&gt;&quot;.my_algorithm.out&quot; -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>&quot;.my_algorithm.B&quot;:out&#45;&gt;&quot;.my_algorithm.out&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M285.25,-35.38C293.19,-35.38 301.81,-35.33 309.73,-35.28\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"309.58,-38.78 319.55,-35.2 309.52,-31.78 309.58,-38.78\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ],
+      "text/plain": [
+       "<graphviz.graphs.Digraph at 0x1067572b0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from qref.experimental.rendering import to_graphviz\n",
     "\n",
@@ -309,22 +396,7 @@
     "\n",
     "# Render the Graphviz object in the notebook\n",
     "gv_object"
-   ],
-   "id": "3464d3b49599fe1d",
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 11.0.0 (20240428.1522)\n -->\n<!-- Pages: 1 -->\n<svg width=\"381pt\" height=\"101pt\"\n viewBox=\"0.00 0.00 381.25 101.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 97)\">\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-97 377.25,-97 377.25,4 -4,4\"/>\n<g id=\"clust1\" class=\"cluster\">\n<title>cluster_.my_algorithm</title>\n<path fill=\"none\" stroke=\"black\" d=\"M20,-8C20,-8 353.25,-8 353.25,-8 359.25,-8 365.25,-14 365.25,-20 365.25,-20 365.25,-73 365.25,-73 365.25,-79 359.25,-85 353.25,-85 353.25,-85 20,-85 20,-85 14,-85 8,-79 8,-73 8,-73 8,-20 8,-20 8,-14 14,-8 20,-8\"/>\n<text text-anchor=\"middle\" x=\"186.62\" y=\"-67.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">my_algorithm</text>\n</g>\n<!-- .my_algorithm.in -->\n<g id=\"node1\" class=\"node\">\n<title>.my_algorithm.in</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"34\" cy=\"-35\" rx=\"18\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"34\" y=\"-31.12\" font-family=\"Times,serif\" font-size=\"10.00\">in</text>\n</g>\n<!-- .my_algorithm.A -->\n<g id=\"node3\" class=\"node\">\n<title>.my_algorithm.A</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M100,-17C100,-17 157,-17 157,-17 163,-17 169,-23 169,-29 169,-29 169,-41 169,-41 169,-47 163,-53 157,-53 157,-53 100,-53 100,-53 94,-53 88,-47 88,-41 88,-41 88,-29 88,-29 88,-23 94,-17 100,-17\"/>\n<text text-anchor=\"middle\" x=\"100.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"113,-17.75 113,-53\"/>\n<text text-anchor=\"middle\" x=\"125.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">A</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"138,-17.75 138,-53\"/>\n<text text-anchor=\"middle\" x=\"153.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n</g>\n<!-- .my_algorithm.in&#45;&gt;.my_algorithm.A -->\n<g id=\"edge3\" class=\"edge\">\n<title>.my_algorithm.in&#45;&gt;.my_algorithm.A:in</title>\n<path fill=\"none\" stroke=\"black\" d=\"M52.19,-35.18C59.4,-35.25 68.11,-35.32 76.77,-35.35\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"76.48,-38.85 86.49,-35.37 76.49,-31.85 76.48,-38.85\"/>\n</g>\n<!-- .my_algorithm.out -->\n<g id=\"node2\" class=\"node\">\n<title>.my_algorithm.out</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"339.25\" cy=\"-35\" rx=\"18\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"339.25\" y=\"-31.12\" font-family=\"Times,serif\" font-size=\"10.00\">out</text>\n</g>\n<!-- .my_algorithm.B -->\n<g id=\"node4\" class=\"node\">\n<title>.my_algorithm.B</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M217,-17C217,-17 273.25,-17 273.25,-17 279.25,-17 285.25,-23 285.25,-29 285.25,-29 285.25,-41 285.25,-41 285.25,-47 279.25,-53 273.25,-53 273.25,-53 217,-53 217,-53 211,-53 205,-47 205,-41 205,-41 205,-29 205,-29 205,-23 211,-17 217,-17\"/>\n<text text-anchor=\"middle\" x=\"217.5\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"230,-17.75 230,-53\"/>\n<text text-anchor=\"middle\" x=\"242.12\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">B</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"254.25,-17.75 254.25,-53\"/>\n<text text-anchor=\"middle\" x=\"269.75\" y=\"-31.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n</g>\n<!-- .my_algorithm.A&#45;&gt;.my_algorithm.B -->\n<g id=\"edge1\" class=\"edge\">\n<title>.my_algorithm.A:out&#45;&gt;.my_algorithm.B:in</title>\n<path fill=\"none\" stroke=\"black\" d=\"M169,-35.38C180.38,-35.38 185.68,-35.38 193.55,-35.38\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"193.49,-38.88 203.49,-35.38 193.49,-31.88 193.49,-38.88\"/>\n</g>\n<!-- .my_algorithm.B&#45;&gt;.my_algorithm.out -->\n<g id=\"edge2\" class=\"edge\">\n<title>.my_algorithm.B:out&#45;&gt;.my_algorithm.out</title>\n<path fill=\"none\" stroke=\"black\" d=\"M285.25,-35.38C293.19,-35.38 301.81,-35.33 309.73,-35.28\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"309.58,-38.78 319.55,-35.2 309.52,-31.78 309.58,-38.78\"/>\n</g>\n</g>\n</svg>\n",
-      "text/plain": [
-       "<graphviz.graphs.Digraph at 0x113b577a0>"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 37
+   ]
   },
   {
    "cell_type": "markdown",
@@ -363,6 +435,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "f3bfa36d-b208-4488-abd6-8b020ef6cffc",
    "metadata": {
     "ExecuteTime": {
@@ -370,13 +443,12 @@
      "start_time": "2024-06-24T20:58:19.589741Z"
     }
    },
+   "outputs": [],
    "source": [
     "from bartiq.integrations import qref_to_bartiq\n",
     "\n",
     "uncompiled_routine = qref_to_bartiq(my_algorithm_qref)"
-   ],
-   "outputs": [],
-   "execution_count": 38
+   ]
   },
   {
    "cell_type": "markdown",
@@ -390,6 +462,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "ef6e5a99-9537-4a9a-aea2-ddf4ec28c5df",
    "metadata": {
     "ExecuteTime": {
@@ -397,9 +470,6 @@
      "start_time": "2024-06-24T20:58:19.601383Z"
     }
    },
-   "source": [
-    "uncompiled_routine.children[\"A\"].resources"
-   ],
    "outputs": [
     {
      "data": {
@@ -407,12 +477,14 @@
        "{'T_gates': <Resource name=\"T_gates\" value=\"2*n_a + x\">}"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 39
+   "source": [
+    "uncompiled_routine.children[\"A\"].resources"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -426,6 +498,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "71860050-361e-478e-b6c8-495c9b0bb6fe",
    "metadata": {
     "ExecuteTime": {
@@ -433,9 +506,6 @@
      "start_time": "2024-06-24T20:58:19.625793Z"
     }
    },
-   "source": [
-    "uncompiled_routine.ports[\"out\"]"
-   ],
    "outputs": [
     {
      "data": {
@@ -443,12 +513,14 @@
        "Port(my_algorithm.#out, size=None, output)"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 40
+   "source": [
+    "uncompiled_routine.ports[\"out\"]"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -460,6 +532,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "da6566d1-f14b-4531-8029-4134143f785f",
    "metadata": {
     "ExecuteTime": {
@@ -467,9 +540,6 @@
      "start_time": "2024-06-24T20:58:19.652567Z"
     }
    },
-   "source": [
-    "uncompiled_routine.resources"
-   ],
    "outputs": [
     {
      "data": {
@@ -477,12 +547,14 @@
        "{}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 41
+   "source": [
+    "uncompiled_routine.resources"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -499,6 +571,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "id": "0163c4b5-16a6-4510-9210-dc84f6711c61",
    "metadata": {
     "ExecuteTime": {
@@ -506,13 +579,21 @@
      "start_time": "2024-06-24T20:58:19.667445Z"
     }
    },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kjalowiecki/Projects/bartiq/src/bartiq/compilation/_compile.py:117: UserWarning: Found the following issues with the provided routine after the compilation has finished: [\"Symbol n_b found in subroutine: my_algorithm.B, which is not among top level params: {'z', 'n'}.\"]\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "from bartiq import compile_routine\n",
     "\n",
     "compiled_routine = compile_routine(uncompiled_routine)"
-   ],
-   "outputs": [],
-   "execution_count": 42
+   ]
   },
   {
    "cell_type": "markdown",
@@ -524,6 +605,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "id": "e017c894-5203-4958-9f0f-f85904a1ad0b",
    "metadata": {
     "ExecuteTime": {
@@ -531,11 +613,6 @@
      "start_time": "2024-06-24T20:58:19.720524Z"
     }
    },
-   "source": [
-    "print(\"T gates for A:\", compiled_routine.children[\"A\"].resources[\"T_gates\"].value)\n",
-    "print(\"Output size:\", compiled_routine.ports[\"out\"].size)\n",
-    "print(\"Total T gates:\", compiled_routine.resources[\"T_gates\"].value)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -547,7 +624,11 @@
      ]
     }
    ],
-   "execution_count": 43
+   "source": [
+    "print(\"T gates for A:\", compiled_routine.children[\"A\"].resources[\"T_gates\"].value)\n",
+    "print(\"Output size:\", compiled_routine.ports[\"out\"].size)\n",
+    "print(\"Total T gates:\", compiled_routine.resources[\"T_gates\"].value)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -575,6 +656,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "id": "4c232bc3-77bb-4bd8-a587-b6591d539c41",
    "metadata": {
     "ExecuteTime": {
@@ -582,22 +664,6 @@
      "start_time": "2024-06-24T20:58:19.739023Z"
     }
    },
-   "source": [
-    "from bartiq import evaluate\n",
-    "\n",
-    "print(\"Different values of n:\")\n",
-    "for n in range(6, 16, 2):\n",
-    "    assignments = [f\"n={n}\"]\n",
-    "    evaluated_routine = evaluate(compiled_routine, assignments)\n",
-    "    print(f\"n = {n}, total T gates:\", evaluated_routine.resources[\"T_gates\"].value)\n",
-    "\n",
-    "z = 5\n",
-    "assignments = [f\"n={n}\", f\"z={z}\"]\n",
-    "evaluated_routine = evaluate(compiled_routine, assignments)\n",
-    "print(f\"For n={n}, z={z}\")\n",
-    "\n",
-    "print(\"Total T gates:\", evaluated_routine.resources[\"T_gates\"].value)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -614,7 +680,22 @@
      ]
     }
    ],
-   "execution_count": 44
+   "source": [
+    "from bartiq import evaluate\n",
+    "\n",
+    "print(\"Different values of n:\")\n",
+    "for n in range(6, 16, 2):\n",
+    "    assignments = [f\"n={n}\"]\n",
+    "    evaluated_routine = evaluate(compiled_routine, assignments)\n",
+    "    print(f\"n = {n}, total T gates:\", evaluated_routine.resources[\"T_gates\"].value)\n",
+    "\n",
+    "z = 5\n",
+    "assignments = [f\"n={n}\", f\"z={z}\"]\n",
+    "evaluated_routine = evaluate(compiled_routine, assignments)\n",
+    "print(f\"For n={n}, z={z}\")\n",
+    "\n",
+    "print(\"Total T gates:\", evaluated_routine.resources[\"T_gates\"].value)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -649,7 +730,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/01_basic_example.ipynb
+++ b/docs/tutorials/01_basic_example.ipynb
@@ -377,7 +377,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x1067572b0>"
+       "<graphviz.graphs.Digraph at 0x107754b50>"
       ]
      },
      "execution_count": 7,

--- a/docs/tutorials/02_alias_sampling_basic.ipynb
+++ b/docs/tutorials/02_alias_sampling_basic.ipynb
@@ -617,7 +617,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x103ed1270>"
+       "<graphviz.graphs.Digraph at 0x107595ff0>"
       ]
      },
      "execution_count": 8,
@@ -676,7 +676,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/kjalowiecki/Projects/bartiq/src/bartiq/compilation/_compile.py:117: UserWarning: Found the following issues with the provided routine after the compilation has finished: [\"Symbol P_2 found in subroutine: alias_sampling.swap.passthrough_2, which is not among top level params: {'L', 'R', 'mu'}.\", \"Symbol P_1 found in subroutine: alias_sampling.swap.passthrough_1, which is not among top level params: {'L', 'R', 'mu'}.\", \"Symbol P_2 found in subroutine: alias_sampling.swap, which is not among top level params: {'L', 'R', 'mu'}.\"]\n",
+      "/Users/kjalowiecki/Projects/bartiq/src/bartiq/compilation/_compile.py:117: UserWarning: Found the following issues with the provided routine after the compilation has finished: [\"Symbol P_2 found in subroutine: alias_sampling.swap.passthrough_2, which is not among top level params: {'mu', 'L', 'R'}.\", \"Symbol P_1 found in subroutine: alias_sampling.swap.passthrough_1, which is not among top level params: {'mu', 'L', 'R'}.\", \"Symbol P_2 found in subroutine: alias_sampling.swap, which is not among top level params: {'mu', 'L', 'R'}.\"]\n",
       "  warnings.warn(\n"
      ]
     }
@@ -710,8 +710,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "T_gates: 4*L + 8*L/multiplicity(2, L) + 4*mu + swap.O(log2(L)) - 8\n",
-      "rotations: 2\n"
+      "rotations: 2\n",
+      "T_gates: 4*L + 8*L/multiplicity(2, L) + 4*mu + swap.O(log2(L)) - 8\n"
      ]
     }
    ],
@@ -752,8 +752,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "T_gates: swap.O(log2(120)) + 824\n",
-      "rotations: 2\n"
+      "rotations: 2\n",
+      "T_gates: swap.O(log2(120)) + 824\n"
      ]
     }
    ],
@@ -794,8 +794,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "T_gates: 4*L + 8*L/multiplicity(2, L) + 4*mu + O(log2(L)) - 8\n",
-      "rotations: 2\n"
+      "rotations: 2\n",
+      "T_gates: 4*L + 8*L/multiplicity(2, L) + 4*mu + O(log2(L)) - 8\n"
      ]
     }
    ],
@@ -828,8 +828,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "T_gates: 831\n",
-      "rotations: 2\n"
+      "rotations: 2\n",
+      "T_gates: 831\n"
      ]
     }
    ],
@@ -886,7 +886,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2026b27b761545808b9204edea7ff9e5",
+       "model_id": "6c5429bfe5934df19cc44b5edb8c20dd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -937,8 +937,8 @@
        "&\\text{temp\\_2} = 8\\\\\n",
        "&\\text{temp\\_3} = 1\\newline\n",
        "&\\underline{\\text{Resources:}}\\\\\n",
-       "&T_{\\text{gates}} = 831\\\\\n",
        "&rotations = 2\\\\\n",
+       "&T_{\\text{gates}} = 831\\\\\n",
        "&\\text{usp}.\\!T_{\\text{gates}} = 320\\\\\n",
        "&\\text{usp}.\\!rotations = 2\\\\\n",
        "&\\text{qrom}.\\!T_{\\text{gates}} = 476\\\\\n",

--- a/docs/tutorials/02_alias_sampling_basic.ipynb
+++ b/docs/tutorials/02_alias_sampling_basic.ipynb
@@ -88,6 +88,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "fa6d5b43-0eac-4f6f-84de-1df68b8d0d8e",
    "metadata": {
     "ExecuteTime": {
@@ -95,6 +96,7 @@
      "start_time": "2024-06-24T21:06:39.004429Z"
     }
    },
+   "outputs": [],
    "source": [
     "usp_dict = {\n",
     "    \"name\": \"usp\",\n",
@@ -108,11 +110,9 @@
     "        {\"name\": \"rotations\", \"type\": \"additive\", \"value\": \"2\"},\n",
     "    ],\n",
     "    \"input_params\": [\"L\"],\n",
-    "    \"local_variables\": [\"R=ceiling(log_2(L))\"],\n",
+    "    \"local_variables\": {\"R\": \"ceiling(log_2(L))\"},\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 41
+   ]
   },
   {
    "cell_type": "markdown",
@@ -127,6 +127,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "9cbe85ec-c435-4e60-8561-9b151de06b41",
    "metadata": {
     "ExecuteTime": {
@@ -134,6 +135,7 @@
      "start_time": "2024-06-24T21:06:39.230480Z"
     }
    },
+   "outputs": [],
    "source": [
     "had_dict = {\n",
     "    \"name\": \"had\",\n",
@@ -143,12 +145,11 @@
     "        {\"name\": \"out\", \"direction\": \"output\", \"size\": \"N\"},\n",
     "    ],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 42
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "ef43c139-304f-473f-b718-16883760658e",
    "metadata": {
     "ExecuteTime": {
@@ -156,6 +157,7 @@
      "start_time": "2024-06-24T21:06:39.363485Z"
     }
    },
+   "outputs": [],
    "source": [
     "qrom_dict = {\n",
     "    \"name\": \"qrom\",\n",
@@ -170,14 +172,13 @@
     "    ],\n",
     "    \"resources\": [{\"name\": \"T_gates\", \"type\": \"additive\", \"value\": \"4*L-4\"}],\n",
     "    \"input_params\": [\"L\", \"mu\"],\n",
-    "    \"local_variables\": [\"R=ceiling(log_2(L))\"],\n",
+    "    \"local_variables\": {\"R\": \"ceiling(log_2(L))\"},\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 43
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "698c0b16-2e5f-4c9f-bc81-89f0bbed9611",
    "metadata": {
     "ExecuteTime": {
@@ -185,6 +186,7 @@
      "start_time": "2024-06-24T21:06:39.442880Z"
     }
    },
+   "outputs": [],
    "source": [
     "compare_dict = {\n",
     "    \"name\": \"compare\",\n",
@@ -200,12 +202,11 @@
     "    \"resources\": [{\"name\": \"T_gates\", \"type\": \"additive\", \"value\": \"4*mu-4\"}],\n",
     "    \"input_params\": [\"mu\"],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 44
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "da5c61bf-7fb2-47d1-a0f5-d15b32147673",
    "metadata": {
     "ExecuteTime": {
@@ -213,6 +214,7 @@
      "start_time": "2024-06-24T21:06:39.553767Z"
     }
    },
+   "outputs": [],
    "source": [
     "swap_dict = {\n",
     "    \"name\": \"swap\",\n",
@@ -233,9 +235,7 @@
     "    ],\n",
     "    \"input_params\": [\"X\"],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 45
+   ]
   },
   {
    "cell_type": "markdown",
@@ -257,6 +257,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "b066f011-96e1-4544-81bf-cdc7083b3f73",
    "metadata": {
     "ExecuteTime": {
@@ -264,6 +265,7 @@
      "start_time": "2024-06-24T21:06:39.658696Z"
     }
    },
+   "outputs": [],
    "source": [
     "alias_sampling_dict = {\n",
     "    \"name\": \"alias_sampling\",\n",
@@ -300,18 +302,17 @@
     "        {\"source\": \"swap.out_control\", \"target\": \"temp_3\"},\n",
     "    ],\n",
     "    \"input_params\": [\"mu\", \"L\"],\n",
-    "    \"local_variables\": [\"R=ceiling(log_2(L))\"],\n",
+    "    \"local_variables\": {\"R\": \"ceiling(log_2(L))\"},\n",
     "    \"linked_params\": [\n",
     "        {\"source\": \"L\", \"targets\": [\"usp.L\", \"qrom.L\", \"swap.X\"]},\n",
     "        {\"source\": \"mu\", \"targets\": [\"qrom.mu\", \"compare.mu\"]},\n",
     "    ],\n",
     "}"
-   ],
-   "outputs": [],
-   "execution_count": 46
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "e3d17a61-4b9e-48e9-901a-231da501f41b",
    "metadata": {
     "ExecuteTime": {
@@ -319,21 +320,23 @@
      "start_time": "2024-06-24T21:06:39.795127Z"
     }
    },
+   "outputs": [],
    "source": [
     "alias_sampling_qref = {\"version\": \"v1\", \"program\": alias_sampling_dict}"
-   ],
-   "outputs": [],
-   "execution_count": 47
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Additionally, you can examine how the circuit is represented in `qref` format by visualizing it. ",
-   "id": "a97dfdd428b669cb"
+   "id": "a97dfdd428b669cb",
+   "metadata": {},
+   "source": [
+    "Additionally, you can examine how the circuit is represented in `qref` format by visualizing it. "
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "dfdf59f8a2ef16c5",
+   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info admonition note\">\n",
     "    <p class=\"admonition-title\"><b>NOTE:</b></p>\n",
@@ -341,23 +344,287 @@
     "        To use the <a href=\"https://github.com/PsiQ/qref\">qref</a> rendering tool in Jupyter Notebook, ensure the Graphviz software is installed on your OS and that its executables are included in your system variables. For installation instructions, please refer to the <a href=\"https://graphviz.org/download/\">Graphviz download page</a>.\n",
     "    </p>\n",
     "</div>"
-   ],
-   "id": "dfdf59f8a2ef16c5"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "<p>Once installed, proceed to visualize the representation of the circuit.</p>",
-   "id": "ff432b4dac9921c1"
+   "id": "ff432b4dac9921c1",
+   "metadata": {},
+   "source": [
+    "<p>Once installed, proceed to visualize the representation of the circuit.</p>"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "492ad64333e398fa",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-24T21:06:40.822960Z",
      "start_time": "2024-06-24T21:06:39.876790Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 12.0.0 (20240704.0754)\n",
+       " -->\n",
+       "<!-- Pages: 1 -->\n",
+       "<svg width=\"926pt\" height=\"403pt\"\n",
+       " viewBox=\"0.00 0.00 926.20 403.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 399)\">\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-399 922.2,-399 922.2,4 -4,4\"/>\n",
+       "<g id=\"clust1\" class=\"cluster\">\n",
+       "<title>cluster_.alias_sampling</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M20,-8C20,-8 898.2,-8 898.2,-8 904.2,-8 910.2,-14 910.2,-20 910.2,-20 910.2,-375 910.2,-375 910.2,-381 904.2,-387 898.2,-387 898.2,-387 20,-387 20,-387 14,-387 8,-381 8,-375 8,-375 8,-20 8,-20 8,-14 14,-8 20,-8\"/>\n",
+       "<text text-anchor=\"middle\" x=\"459.1\" y=\"-369.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">alias_sampling</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_0&quot; -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.In_0&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-198\" rx=\"20.56\" ry=\"20.56\"/>\n",
+       "<text text-anchor=\"middle\" x=\"36.56\" y=\"-194.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_0</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.usp&quot; -->\n",
+       "<g id=\"node15\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.usp&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M105.12,-180C105.12,-180 169.62,-180 169.62,-180 175.62,-180 181.62,-186 181.62,-192 181.62,-192 181.62,-204 181.62,-204 181.62,-210 175.62,-216 169.62,-216 169.62,-216 105.12,-216 105.12,-216 99.12,-216 93.12,-210 93.12,-204 93.12,-204 93.12,-192 93.12,-192 93.12,-186 99.12,-180 105.12,-180\"/>\n",
+       "<text text-anchor=\"middle\" x=\"105.62\" y=\"-194.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"118.12,-180.75 118.12,-216\"/>\n",
+       "<text text-anchor=\"middle\" x=\"134.37\" y=\"-194.1\" font-family=\"Times,serif\" font-size=\"12.00\">usp</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"150.62,-180.75 150.62,-216\"/>\n",
+       "<text text-anchor=\"middle\" x=\"166.12\" y=\"-194.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_0&quot;&#45;&gt;&quot;.alias_sampling.usp&quot; -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.In_0&quot;&#45;&gt;&quot;.alias_sampling.usp&quot;:in</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M57.62,-198.2C64.88,-198.26 73.38,-198.32 81.8,-198.35\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"81.6,-201.85 91.61,-198.37 81.62,-194.85 81.6,-201.85\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_1&quot; -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.In_1&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-80\" rx=\"20.56\" ry=\"20.56\"/>\n",
+       "<text text-anchor=\"middle\" x=\"36.56\" y=\"-76.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_1</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.had&quot; -->\n",
+       "<g id=\"node12\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.had&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M262.25,-73C262.25,-73 327.5,-73 327.5,-73 333.5,-73 339.5,-79 339.5,-85 339.5,-85 339.5,-97 339.5,-97 339.5,-103 333.5,-109 327.5,-109 327.5,-109 262.25,-109 262.25,-109 256.25,-109 250.25,-103 250.25,-97 250.25,-97 250.25,-85 250.25,-85 250.25,-79 256.25,-73 262.25,-73\"/>\n",
+       "<text text-anchor=\"middle\" x=\"262.75\" y=\"-87.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"275.25,-73.75 275.25,-109\"/>\n",
+       "<text text-anchor=\"middle\" x=\"291.87\" y=\"-87.1\" font-family=\"Times,serif\" font-size=\"12.00\">had</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"308.5,-73.75 308.5,-109\"/>\n",
+       "<text text-anchor=\"middle\" x=\"324\" y=\"-87.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_1&quot;&#45;&gt;&quot;.alias_sampling.had&quot; -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.In_1&quot;&#45;&gt;&quot;.alias_sampling.had&quot;:in</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M57.39,-81.78C92.87,-84.81 169.88,-90.71 237.97,-91.32\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"237.72,-94.82 247.73,-91.37 237.75,-87.82 237.72,-94.82\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_2&quot; -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.In_2&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-316\" rx=\"20.56\" ry=\"20.56\"/>\n",
+       "<text text-anchor=\"middle\" x=\"36.56\" y=\"-312.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_2</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.qrom&quot; -->\n",
+       "<g id=\"node13\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.qrom&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M229.62,-193.62C229.62,-193.62 360.12,-193.62 360.12,-193.62 366.12,-193.62 372.12,-199.62 372.12,-205.62 372.12,-205.62 372.12,-248.38 372.12,-248.38 372.12,-254.38 366.12,-260.38 360.12,-260.38 360.12,-260.38 229.62,-260.38 229.62,-260.38 223.62,-260.38 217.62,-254.38 217.62,-248.38 217.62,-248.38 217.62,-205.62 217.62,-205.62 217.62,-199.62 223.62,-193.62 229.62,-193.62\"/>\n",
+       "<text text-anchor=\"middle\" x=\"244.75\" y=\"-244.97\" font-family=\"Times,serif\" font-size=\"12.00\">In_alt</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"217.62,-238.12 271.87,-238.12\"/>\n",
+       "<text text-anchor=\"middle\" x=\"244.75\" y=\"-222.72\" font-family=\"Times,serif\" font-size=\"12.00\">In_keep</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"217.62,-215.88 271.87,-215.88\"/>\n",
+       "<text text-anchor=\"middle\" x=\"244.75\" y=\"-200.47\" font-family=\"Times,serif\" font-size=\"12.00\">In_l</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"271.87,-193.62 271.87,-260.38\"/>\n",
+       "<text text-anchor=\"middle\" x=\"292.25\" y=\"-222.72\" font-family=\"Times,serif\" font-size=\"12.00\">qrom</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"312.62,-193.62 312.62,-260.38\"/>\n",
+       "<text text-anchor=\"middle\" x=\"342.37\" y=\"-244.97\" font-family=\"Times,serif\" font-size=\"12.00\">out_alt</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"312.62,-238.12 372.12,-238.12\"/>\n",
+       "<text text-anchor=\"middle\" x=\"342.37\" y=\"-222.72\" font-family=\"Times,serif\" font-size=\"12.00\">out_keep</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"312.62,-215.88 372.12,-215.88\"/>\n",
+       "<text text-anchor=\"middle\" x=\"342.37\" y=\"-200.47\" font-family=\"Times,serif\" font-size=\"12.00\">out_l</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_2&quot;&#45;&gt;&quot;.alias_sampling.qrom&quot; -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.In_2&quot;&#45;&gt;&quot;.alias_sampling.qrom&quot;:In_alt</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M54.18,-305.28C83.24,-287.51 146,-253.54 206.38,-249.62\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"206.23,-253.13 216.11,-249.3 206,-246.13 206.23,-253.13\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_3&quot; -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.In_3&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-257\" rx=\"20.56\" ry=\"20.56\"/>\n",
+       "<text text-anchor=\"middle\" x=\"36.56\" y=\"-253.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_3</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_3&quot;&#45;&gt;&quot;.alias_sampling.qrom&quot; -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.In_3&quot;&#45;&gt;&quot;.alias_sampling.qrom&quot;:In_keep</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M56.84,-251.64C87.55,-243.55 149.91,-228.97 206.41,-227.18\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"206.17,-230.69 216.11,-227.02 206.05,-223.69 206.17,-230.69\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_4&quot; -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.In_4&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-139\" rx=\"20.56\" ry=\"20.56\"/>\n",
+       "<text text-anchor=\"middle\" x=\"36.56\" y=\"-135.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_4</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.compare&quot; -->\n",
+       "<g id=\"node11\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.compare&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M420.12,-83.62C420.12,-83.62 576.87,-83.62 576.87,-83.62 582.87,-83.62 588.87,-89.62 588.87,-95.62 588.87,-95.62 588.87,-138.38 588.87,-138.38 588.87,-144.38 582.87,-150.38 576.87,-150.38 576.87,-150.38 420.12,-150.38 420.12,-150.38 414.12,-150.38 408.12,-144.38 408.12,-138.38 408.12,-138.38 408.12,-95.62 408.12,-95.62 408.12,-89.62 414.12,-83.62 420.12,-83.62\"/>\n",
+       "<text text-anchor=\"middle\" x=\"437.87\" y=\"-134.97\" font-family=\"Times,serif\" font-size=\"12.00\">In_flag</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"408.12,-128.12 467.62,-128.12\"/>\n",
+       "<text text-anchor=\"middle\" x=\"437.87\" y=\"-112.72\" font-family=\"Times,serif\" font-size=\"12.00\">In_keep</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"408.12,-105.88 467.62,-105.88\"/>\n",
+       "<text text-anchor=\"middle\" x=\"437.87\" y=\"-90.47\" font-family=\"Times,serif\" font-size=\"12.00\">In_sigma</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"467.62,-83.62 467.62,-150.38\"/>\n",
+       "<text text-anchor=\"middle\" x=\"495.87\" y=\"-112.72\" font-family=\"Times,serif\" font-size=\"12.00\">compare</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"524.12,-83.62 524.12,-150.38\"/>\n",
+       "<text text-anchor=\"middle\" x=\"556.5\" y=\"-134.97\" font-family=\"Times,serif\" font-size=\"12.00\">out_flag</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"524.12,-128.12 588.87,-128.12\"/>\n",
+       "<text text-anchor=\"middle\" x=\"556.5\" y=\"-112.72\" font-family=\"Times,serif\" font-size=\"12.00\">out_keep</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"524.12,-105.88 588.87,-105.88\"/>\n",
+       "<text text-anchor=\"middle\" x=\"556.5\" y=\"-90.47\" font-family=\"Times,serif\" font-size=\"12.00\">out_sigma</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.In_4&quot;&#45;&gt;&quot;.alias_sampling.compare&quot; -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.In_4&quot;&#45;&gt;&quot;.alias_sampling.compare&quot;:In_flag</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M57.25,-139.02C110.97,-139.08 264.93,-139.24 396.66,-139.25\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"396.61,-142.75 406.61,-139.25 396.61,-135.75 396.61,-142.75\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.out_0&quot; -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.out_0&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-259\" rx=\"23.67\" ry=\"23.67\"/>\n",
+       "<text text-anchor=\"middle\" x=\"874.53\" y=\"-255.12\" font-family=\"Times,serif\" font-size=\"10.00\">out_0</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.temp_0&quot; -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.temp_0&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-44\" rx=\"27.66\" ry=\"27.66\"/>\n",
+       "<text text-anchor=\"middle\" x=\"874.53\" y=\"-40.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_0</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.temp_1&quot; -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.temp_1&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-190\" rx=\"27.66\" ry=\"27.66\"/>\n",
+       "<text text-anchor=\"middle\" x=\"874.53\" y=\"-186.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_1</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.temp_2&quot; -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.temp_2&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-117\" rx=\"27.66\" ry=\"27.66\"/>\n",
+       "<text text-anchor=\"middle\" x=\"874.53\" y=\"-113.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_2</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.temp_3&quot; -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.temp_3&quot;</title>\n",
+       "<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-328\" rx=\"27.66\" ry=\"27.66\"/>\n",
+       "<text text-anchor=\"middle\" x=\"874.53\" y=\"-324.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_3</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.compare&quot;&#45;&gt;&quot;.alias_sampling.temp_0&quot; -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.compare&quot;:out_sigma&#45;&gt;&quot;.alias_sampling.temp_0&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M588.87,-94.75C678.9,-94.75 782.49,-69.84 836.46,-54.93\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"837.38,-58.3 846.06,-52.23 835.49,-51.57 837.38,-58.3\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.compare&quot;&#45;&gt;&quot;.alias_sampling.temp_2&quot; -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.compare&quot;:out_keep&#45;&gt;&quot;.alias_sampling.temp_2&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M588.87,-117C677.04,-117 780.58,-117 835.24,-117\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"834.94,-120.5 844.94,-117 834.94,-113.5 834.94,-120.5\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.swap&quot; -->\n",
+       "<g id=\"node14\" class=\"node\">\n",
+       "<title>&quot;.alias_sampling.swap&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M636.87,-201.62C636.87,-201.62 798.87,-201.62 798.87,-201.62 804.87,-201.62 810.87,-207.62 810.87,-213.62 810.87,-213.62 810.87,-256.38 810.87,-256.38 810.87,-262.38 804.87,-268.38 798.87,-268.38 798.87,-268.38 636.87,-268.38 636.87,-268.38 630.87,-268.38 624.87,-262.38 624.87,-256.38 624.87,-256.38 624.87,-213.62 624.87,-213.62 624.87,-207.62 630.87,-201.62 636.87,-201.62\"/>\n",
+       "<text text-anchor=\"middle\" x=\"659.87\" y=\"-252.97\" font-family=\"Times,serif\" font-size=\"12.00\">In_control</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"624.87,-246.12 694.87,-246.12\"/>\n",
+       "<text text-anchor=\"middle\" x=\"659.87\" y=\"-230.72\" font-family=\"Times,serif\" font-size=\"12.00\">In_target_0</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"624.87,-223.88 694.87,-223.88\"/>\n",
+       "<text text-anchor=\"middle\" x=\"659.87\" y=\"-208.47\" font-family=\"Times,serif\" font-size=\"12.00\">In_target_1</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"694.87,-201.62 694.87,-268.38\"/>\n",
+       "<text text-anchor=\"middle\" x=\"715.25\" y=\"-230.72\" font-family=\"Times,serif\" font-size=\"12.00\">swap</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"735.62,-201.62 735.62,-268.38\"/>\n",
+       "<text text-anchor=\"middle\" x=\"773.25\" y=\"-252.97\" font-family=\"Times,serif\" font-size=\"12.00\">out_control</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"735.62,-246.12 810.87,-246.12\"/>\n",
+       "<text text-anchor=\"middle\" x=\"773.25\" y=\"-230.72\" font-family=\"Times,serif\" font-size=\"12.00\">out_target_0</text>\n",
+       "<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"735.62,-223.88 810.87,-223.88\"/>\n",
+       "<text text-anchor=\"middle\" x=\"773.25\" y=\"-208.47\" font-family=\"Times,serif\" font-size=\"12.00\">out_target_1</text>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.compare&quot;&#45;&gt;&quot;.alias_sampling.swap&quot; -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.compare&quot;:out_flag&#45;&gt;&quot;.alias_sampling.swap&quot;:In_control</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M588.87,-139.25C639.21,-139.25 581.26,-238.68 613.83,-255\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"612.89,-258.38 623.39,-256.95 614.29,-251.52 612.89,-258.38\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.had&quot;&#45;&gt;&quot;.alias_sampling.compare&quot; -->\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.had&quot;:out&#45;&gt;&quot;.alias_sampling.compare&quot;:In_sigma</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M340.5,-91.38C366.36,-91.38 375.49,-93.87 396.65,-94.57\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"396.56,-98.07 406.61,-94.73 396.67,-91.07 396.56,-98.07\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.qrom&quot;&#45;&gt;&quot;.alias_sampling.compare&quot; -->\n",
+       "<g id=\"edge11\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.qrom&quot;:out_keep&#45;&gt;&quot;.alias_sampling.compare&quot;:In_keep</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M372.12,-227C418.94,-227 367.75,-135.88 396.95,-119.5\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"397.65,-122.93 406.65,-117.33 396.12,-116.1 397.65,-122.93\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.qrom&quot;&#45;&gt;&quot;.alias_sampling.swap&quot; -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.qrom&quot;:out_alt&#45;&gt;&quot;.alias_sampling.swap&quot;:In_target_1</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M372.12,-249.25C390.27,-249.25 390.71,-235.11 408.12,-230 497.14,-203.9 525.94,-212.01 613.59,-212.71\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"613.35,-216.2 623.36,-212.74 613.37,-209.2 613.35,-216.2\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.qrom&quot;&#45;&gt;&quot;.alias_sampling.swap&quot; -->\n",
+       "<g id=\"edge12\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.qrom&quot;:out_l&#45;&gt;&quot;.alias_sampling.swap&quot;:In_target_0</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M372.12,-204.75C390.48,-204.75 390.48,-219.94 408.12,-225 497.11,-250.52 526.12,-236.26 613.61,-235.08\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"613.38,-238.58 623.36,-235.01 613.34,-231.58 613.38,-238.58\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.swap&quot;&#45;&gt;&quot;.alias_sampling.out_0&quot; -->\n",
+       "<g id=\"edge14\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.swap&quot;:out_target_0&#45;&gt;&quot;.alias_sampling.out_0&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M810.87,-235C821.91,-235 833.36,-238.29 843.4,-242.43\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"841.74,-245.52 852.29,-246.51 844.66,-239.15 841.74,-245.52\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.swap&quot;&#45;&gt;&quot;.alias_sampling.temp_1&quot; -->\n",
+       "<g id=\"edge15\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.swap&quot;:out_target_1&#45;&gt;&quot;.alias_sampling.temp_1&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M810.87,-212.75C820.42,-212.75 830.32,-210.39 839.35,-207.19\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"840.48,-210.51 848.45,-203.53 837.87,-204.01 840.48,-210.51\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.swap&quot;&#45;&gt;&quot;.alias_sampling.temp_3&quot; -->\n",
+       "<g id=\"edge13\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.swap&quot;:out_control&#45;&gt;&quot;.alias_sampling.temp_3&quot;</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M810.87,-257.25C816.61,-257.25 834.78,-278.36 850.09,-297.52\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"847.2,-299.52 856.14,-305.2 852.7,-295.18 847.2,-299.52\"/>\n",
+       "</g>\n",
+       "<!-- &quot;.alias_sampling.usp&quot;&#45;&gt;&quot;.alias_sampling.qrom&quot; -->\n",
+       "<g id=\"edge16\" class=\"edge\">\n",
+       "<title>&quot;.alias_sampling.usp&quot;:out&#45;&gt;&quot;.alias_sampling.qrom&quot;:In_l</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M181.62,-198.38C193.3,-198.38 198.4,-201.67 206.37,-203.52\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"205.8,-206.98 216.12,-204.59 206.56,-200.02 205.8,-206.98\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ],
+      "text/plain": [
+       "<graphviz.graphs.Digraph at 0x103ed1270>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from qref.experimental.rendering import to_graphviz\n",
     "\n",
@@ -367,31 +634,19 @@
     "# Render the Graphviz object to a PNG file\n",
     "gv_object.render(\"alias_sampling\", format=\"png\")\n",
     "gv_object"
-   ],
-   "id": "492ad64333e398fa",
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 11.0.0 (20240428.1522)\n -->\n<!-- Pages: 1 -->\n<svg width=\"926pt\" height=\"403pt\"\n viewBox=\"0.00 0.00 926.20 403.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 399)\">\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-399 922.2,-399 922.2,4 -4,4\"/>\n<g id=\"clust1\" class=\"cluster\">\n<title>cluster_.alias_sampling</title>\n<path fill=\"none\" stroke=\"black\" d=\"M20,-8C20,-8 898.2,-8 898.2,-8 904.2,-8 910.2,-14 910.2,-20 910.2,-20 910.2,-375 910.2,-375 910.2,-381 904.2,-387 898.2,-387 898.2,-387 20,-387 20,-387 14,-387 8,-381 8,-375 8,-375 8,-20 8,-20 8,-14 14,-8 20,-8\"/>\n<text text-anchor=\"middle\" x=\"459.1\" y=\"-369.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">alias_sampling</text>\n</g>\n<!-- .alias_sampling.In_0 -->\n<g id=\"node1\" class=\"node\">\n<title>.alias_sampling.In_0</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-198\" rx=\"20.56\" ry=\"20.56\"/>\n<text text-anchor=\"middle\" x=\"36.56\" y=\"-194.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_0</text>\n</g>\n<!-- .alias_sampling.usp -->\n<g id=\"node15\" class=\"node\">\n<title>.alias_sampling.usp</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M105.12,-180C105.12,-180 169.62,-180 169.62,-180 175.62,-180 181.62,-186 181.62,-192 181.62,-192 181.62,-204 181.62,-204 181.62,-210 175.62,-216 169.62,-216 169.62,-216 105.12,-216 105.12,-216 99.12,-216 93.12,-210 93.12,-204 93.12,-204 93.12,-192 93.12,-192 93.12,-186 99.12,-180 105.12,-180\"/>\n<text text-anchor=\"middle\" x=\"105.62\" y=\"-194.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"118.12,-180.75 118.12,-216\"/>\n<text text-anchor=\"middle\" x=\"134.37\" y=\"-194.1\" font-family=\"Times,serif\" font-size=\"12.00\">usp</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"150.62,-180.75 150.62,-216\"/>\n<text text-anchor=\"middle\" x=\"166.12\" y=\"-194.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n</g>\n<!-- .alias_sampling.In_0&#45;&gt;.alias_sampling.usp -->\n<g id=\"edge1\" class=\"edge\">\n<title>.alias_sampling.In_0&#45;&gt;.alias_sampling.usp:in</title>\n<path fill=\"none\" stroke=\"black\" d=\"M57.62,-198.2C64.88,-198.26 73.38,-198.32 81.8,-198.35\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"81.6,-201.85 91.61,-198.37 81.62,-194.85 81.6,-201.85\"/>\n</g>\n<!-- .alias_sampling.In_1 -->\n<g id=\"node2\" class=\"node\">\n<title>.alias_sampling.In_1</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-80\" rx=\"20.56\" ry=\"20.56\"/>\n<text text-anchor=\"middle\" x=\"36.56\" y=\"-76.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_1</text>\n</g>\n<!-- .alias_sampling.had -->\n<g id=\"node12\" class=\"node\">\n<title>.alias_sampling.had</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M262.25,-73C262.25,-73 327.5,-73 327.5,-73 333.5,-73 339.5,-79 339.5,-85 339.5,-85 339.5,-97 339.5,-97 339.5,-103 333.5,-109 327.5,-109 327.5,-109 262.25,-109 262.25,-109 256.25,-109 250.25,-103 250.25,-97 250.25,-97 250.25,-85 250.25,-85 250.25,-79 256.25,-73 262.25,-73\"/>\n<text text-anchor=\"middle\" x=\"262.75\" y=\"-87.1\" font-family=\"Times,serif\" font-size=\"12.00\">in</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"275.25,-73.75 275.25,-109\"/>\n<text text-anchor=\"middle\" x=\"291.87\" y=\"-87.1\" font-family=\"Times,serif\" font-size=\"12.00\">had</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"308.5,-73.75 308.5,-109\"/>\n<text text-anchor=\"middle\" x=\"324\" y=\"-87.1\" font-family=\"Times,serif\" font-size=\"12.00\">out</text>\n</g>\n<!-- .alias_sampling.In_1&#45;&gt;.alias_sampling.had -->\n<g id=\"edge2\" class=\"edge\">\n<title>.alias_sampling.In_1&#45;&gt;.alias_sampling.had:in</title>\n<path fill=\"none\" stroke=\"black\" d=\"M57.39,-81.78C92.87,-84.81 169.88,-90.71 237.97,-91.32\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"237.72,-94.82 247.73,-91.37 237.75,-87.82 237.72,-94.82\"/>\n</g>\n<!-- .alias_sampling.In_2 -->\n<g id=\"node3\" class=\"node\">\n<title>.alias_sampling.In_2</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-316\" rx=\"20.56\" ry=\"20.56\"/>\n<text text-anchor=\"middle\" x=\"36.56\" y=\"-312.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_2</text>\n</g>\n<!-- .alias_sampling.qrom -->\n<g id=\"node13\" class=\"node\">\n<title>.alias_sampling.qrom</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M229.62,-193.62C229.62,-193.62 360.12,-193.62 360.12,-193.62 366.12,-193.62 372.12,-199.62 372.12,-205.62 372.12,-205.62 372.12,-248.38 372.12,-248.38 372.12,-254.38 366.12,-260.38 360.12,-260.38 360.12,-260.38 229.62,-260.38 229.62,-260.38 223.62,-260.38 217.62,-254.38 217.62,-248.38 217.62,-248.38 217.62,-205.62 217.62,-205.62 217.62,-199.62 223.62,-193.62 229.62,-193.62\"/>\n<text text-anchor=\"middle\" x=\"244.75\" y=\"-244.97\" font-family=\"Times,serif\" font-size=\"12.00\">In_alt</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"217.62,-238.12 271.87,-238.12\"/>\n<text text-anchor=\"middle\" x=\"244.75\" y=\"-222.72\" font-family=\"Times,serif\" font-size=\"12.00\">In_keep</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"217.62,-215.88 271.87,-215.88\"/>\n<text text-anchor=\"middle\" x=\"244.75\" y=\"-200.47\" font-family=\"Times,serif\" font-size=\"12.00\">In_l</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"271.87,-193.62 271.87,-260.38\"/>\n<text text-anchor=\"middle\" x=\"292.25\" y=\"-222.72\" font-family=\"Times,serif\" font-size=\"12.00\">qrom</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"312.62,-193.62 312.62,-260.38\"/>\n<text text-anchor=\"middle\" x=\"342.37\" y=\"-244.97\" font-family=\"Times,serif\" font-size=\"12.00\">out_alt</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"312.62,-238.12 372.12,-238.12\"/>\n<text text-anchor=\"middle\" x=\"342.37\" y=\"-222.72\" font-family=\"Times,serif\" font-size=\"12.00\">out_keep</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"312.62,-215.88 372.12,-215.88\"/>\n<text text-anchor=\"middle\" x=\"342.37\" y=\"-200.47\" font-family=\"Times,serif\" font-size=\"12.00\">out_l</text>\n</g>\n<!-- .alias_sampling.In_2&#45;&gt;.alias_sampling.qrom -->\n<g id=\"edge3\" class=\"edge\">\n<title>.alias_sampling.In_2&#45;&gt;.alias_sampling.qrom:In_alt</title>\n<path fill=\"none\" stroke=\"black\" d=\"M54.18,-305.28C83.24,-287.51 146,-253.54 206.38,-249.62\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"206.23,-253.13 216.11,-249.3 206,-246.13 206.23,-253.13\"/>\n</g>\n<!-- .alias_sampling.In_3 -->\n<g id=\"node4\" class=\"node\">\n<title>.alias_sampling.In_3</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-257\" rx=\"20.56\" ry=\"20.56\"/>\n<text text-anchor=\"middle\" x=\"36.56\" y=\"-253.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_3</text>\n</g>\n<!-- .alias_sampling.In_3&#45;&gt;.alias_sampling.qrom -->\n<g id=\"edge4\" class=\"edge\">\n<title>.alias_sampling.In_3&#45;&gt;.alias_sampling.qrom:In_keep</title>\n<path fill=\"none\" stroke=\"black\" d=\"M56.84,-251.64C87.55,-243.55 149.91,-228.97 206.41,-227.18\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"206.17,-230.69 216.11,-227.02 206.05,-223.69 206.17,-230.69\"/>\n</g>\n<!-- .alias_sampling.In_4 -->\n<g id=\"node5\" class=\"node\">\n<title>.alias_sampling.In_4</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"36.56\" cy=\"-139\" rx=\"20.56\" ry=\"20.56\"/>\n<text text-anchor=\"middle\" x=\"36.56\" y=\"-135.12\" font-family=\"Times,serif\" font-size=\"10.00\">In_4</text>\n</g>\n<!-- .alias_sampling.compare -->\n<g id=\"node11\" class=\"node\">\n<title>.alias_sampling.compare</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M420.12,-83.62C420.12,-83.62 576.87,-83.62 576.87,-83.62 582.87,-83.62 588.87,-89.62 588.87,-95.62 588.87,-95.62 588.87,-138.38 588.87,-138.38 588.87,-144.38 582.87,-150.38 576.87,-150.38 576.87,-150.38 420.12,-150.38 420.12,-150.38 414.12,-150.38 408.12,-144.38 408.12,-138.38 408.12,-138.38 408.12,-95.62 408.12,-95.62 408.12,-89.62 414.12,-83.62 420.12,-83.62\"/>\n<text text-anchor=\"middle\" x=\"437.87\" y=\"-134.97\" font-family=\"Times,serif\" font-size=\"12.00\">In_flag</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"408.12,-128.12 467.62,-128.12\"/>\n<text text-anchor=\"middle\" x=\"437.87\" y=\"-112.72\" font-family=\"Times,serif\" font-size=\"12.00\">In_keep</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"408.12,-105.88 467.62,-105.88\"/>\n<text text-anchor=\"middle\" x=\"437.87\" y=\"-90.47\" font-family=\"Times,serif\" font-size=\"12.00\">In_sigma</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"467.62,-83.62 467.62,-150.38\"/>\n<text text-anchor=\"middle\" x=\"495.87\" y=\"-112.72\" font-family=\"Times,serif\" font-size=\"12.00\">compare</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"524.12,-83.62 524.12,-150.38\"/>\n<text text-anchor=\"middle\" x=\"556.5\" y=\"-134.97\" font-family=\"Times,serif\" font-size=\"12.00\">out_flag</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"524.12,-128.12 588.87,-128.12\"/>\n<text text-anchor=\"middle\" x=\"556.5\" y=\"-112.72\" font-family=\"Times,serif\" font-size=\"12.00\">out_keep</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"524.12,-105.88 588.87,-105.88\"/>\n<text text-anchor=\"middle\" x=\"556.5\" y=\"-90.47\" font-family=\"Times,serif\" font-size=\"12.00\">out_sigma</text>\n</g>\n<!-- .alias_sampling.In_4&#45;&gt;.alias_sampling.compare -->\n<g id=\"edge5\" class=\"edge\">\n<title>.alias_sampling.In_4&#45;&gt;.alias_sampling.compare:In_flag</title>\n<path fill=\"none\" stroke=\"black\" d=\"M57.25,-139.02C110.97,-139.08 264.93,-139.24 396.66,-139.25\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"396.61,-142.75 406.61,-139.25 396.61,-135.75 396.61,-142.75\"/>\n</g>\n<!-- .alias_sampling.out_0 -->\n<g id=\"node6\" class=\"node\">\n<title>.alias_sampling.out_0</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-259\" rx=\"23.67\" ry=\"23.67\"/>\n<text text-anchor=\"middle\" x=\"874.53\" y=\"-255.12\" font-family=\"Times,serif\" font-size=\"10.00\">out_0</text>\n</g>\n<!-- .alias_sampling.temp_0 -->\n<g id=\"node7\" class=\"node\">\n<title>.alias_sampling.temp_0</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-44\" rx=\"27.66\" ry=\"27.66\"/>\n<text text-anchor=\"middle\" x=\"874.53\" y=\"-40.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_0</text>\n</g>\n<!-- .alias_sampling.temp_1 -->\n<g id=\"node8\" class=\"node\">\n<title>.alias_sampling.temp_1</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-190\" rx=\"27.66\" ry=\"27.66\"/>\n<text text-anchor=\"middle\" x=\"874.53\" y=\"-186.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_1</text>\n</g>\n<!-- .alias_sampling.temp_2 -->\n<g id=\"node9\" class=\"node\">\n<title>.alias_sampling.temp_2</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-117\" rx=\"27.66\" ry=\"27.66\"/>\n<text text-anchor=\"middle\" x=\"874.53\" y=\"-113.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_2</text>\n</g>\n<!-- .alias_sampling.temp_3 -->\n<g id=\"node10\" class=\"node\">\n<title>.alias_sampling.temp_3</title>\n<ellipse fill=\"none\" stroke=\"#ffa44a\" stroke-width=\"2\" cx=\"874.53\" cy=\"-328\" rx=\"27.66\" ry=\"27.66\"/>\n<text text-anchor=\"middle\" x=\"874.53\" y=\"-324.12\" font-family=\"Times,serif\" font-size=\"10.00\">temp_3</text>\n</g>\n<!-- .alias_sampling.compare&#45;&gt;.alias_sampling.temp_0 -->\n<g id=\"edge8\" class=\"edge\">\n<title>.alias_sampling.compare:out_sigma&#45;&gt;.alias_sampling.temp_0</title>\n<path fill=\"none\" stroke=\"black\" d=\"M588.87,-94.75C678.9,-94.75 782.49,-69.84 836.46,-54.93\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"837.38,-58.3 846.06,-52.23 835.49,-51.57 837.38,-58.3\"/>\n</g>\n<!-- .alias_sampling.compare&#45;&gt;.alias_sampling.temp_2 -->\n<g id=\"edge7\" class=\"edge\">\n<title>.alias_sampling.compare:out_keep&#45;&gt;.alias_sampling.temp_2</title>\n<path fill=\"none\" stroke=\"black\" d=\"M588.87,-117C677.04,-117 780.58,-117 835.24,-117\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"834.94,-120.5 844.94,-117 834.94,-113.5 834.94,-120.5\"/>\n</g>\n<!-- .alias_sampling.swap -->\n<g id=\"node14\" class=\"node\">\n<title>.alias_sampling.swap</title>\n<path fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" d=\"M636.87,-201.62C636.87,-201.62 798.87,-201.62 798.87,-201.62 804.87,-201.62 810.87,-207.62 810.87,-213.62 810.87,-213.62 810.87,-256.38 810.87,-256.38 810.87,-262.38 804.87,-268.38 798.87,-268.38 798.87,-268.38 636.87,-268.38 636.87,-268.38 630.87,-268.38 624.87,-262.38 624.87,-256.38 624.87,-256.38 624.87,-213.62 624.87,-213.62 624.87,-207.62 630.87,-201.62 636.87,-201.62\"/>\n<text text-anchor=\"middle\" x=\"659.87\" y=\"-252.97\" font-family=\"Times,serif\" font-size=\"12.00\">In_control</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"624.87,-246.12 694.87,-246.12\"/>\n<text text-anchor=\"middle\" x=\"659.87\" y=\"-230.72\" font-family=\"Times,serif\" font-size=\"12.00\">In_target_0</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"624.87,-223.88 694.87,-223.88\"/>\n<text text-anchor=\"middle\" x=\"659.87\" y=\"-208.47\" font-family=\"Times,serif\" font-size=\"12.00\">In_target_1</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"694.87,-201.62 694.87,-268.38\"/>\n<text text-anchor=\"middle\" x=\"715.25\" y=\"-230.72\" font-family=\"Times,serif\" font-size=\"12.00\">swap</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"735.62,-201.62 735.62,-268.38\"/>\n<text text-anchor=\"middle\" x=\"773.25\" y=\"-252.97\" font-family=\"Times,serif\" font-size=\"12.00\">out_control</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"735.62,-246.12 810.87,-246.12\"/>\n<text text-anchor=\"middle\" x=\"773.25\" y=\"-230.72\" font-family=\"Times,serif\" font-size=\"12.00\">out_target_0</text>\n<polyline fill=\"none\" stroke=\"#0288f5\" stroke-width=\"2\" points=\"735.62,-223.88 810.87,-223.88\"/>\n<text text-anchor=\"middle\" x=\"773.25\" y=\"-208.47\" font-family=\"Times,serif\" font-size=\"12.00\">out_target_1</text>\n</g>\n<!-- .alias_sampling.compare&#45;&gt;.alias_sampling.swap -->\n<g id=\"edge6\" class=\"edge\">\n<title>.alias_sampling.compare:out_flag&#45;&gt;.alias_sampling.swap:In_control</title>\n<path fill=\"none\" stroke=\"black\" d=\"M588.87,-139.25C639.21,-139.25 581.26,-238.68 613.83,-255\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"612.89,-258.38 623.39,-256.95 614.29,-251.52 612.89,-258.38\"/>\n</g>\n<!-- .alias_sampling.had&#45;&gt;.alias_sampling.compare -->\n<g id=\"edge9\" class=\"edge\">\n<title>.alias_sampling.had:out&#45;&gt;.alias_sampling.compare:In_sigma</title>\n<path fill=\"none\" stroke=\"black\" d=\"M340.5,-91.38C366.36,-91.38 375.49,-93.87 396.65,-94.57\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"396.56,-98.07 406.61,-94.73 396.67,-91.07 396.56,-98.07\"/>\n</g>\n<!-- .alias_sampling.qrom&#45;&gt;.alias_sampling.compare -->\n<g id=\"edge11\" class=\"edge\">\n<title>.alias_sampling.qrom:out_keep&#45;&gt;.alias_sampling.compare:In_keep</title>\n<path fill=\"none\" stroke=\"black\" d=\"M372.12,-227C418.94,-227 367.75,-135.88 396.95,-119.5\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"397.65,-122.93 406.65,-117.33 396.12,-116.1 397.65,-122.93\"/>\n</g>\n<!-- .alias_sampling.qrom&#45;&gt;.alias_sampling.swap -->\n<g id=\"edge10\" class=\"edge\">\n<title>.alias_sampling.qrom:out_alt&#45;&gt;.alias_sampling.swap:In_target_1</title>\n<path fill=\"none\" stroke=\"black\" d=\"M372.12,-249.25C390.27,-249.25 390.71,-235.11 408.12,-230 497.14,-203.9 525.94,-212.01 613.59,-212.71\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"613.35,-216.2 623.36,-212.74 613.37,-209.2 613.35,-216.2\"/>\n</g>\n<!-- .alias_sampling.qrom&#45;&gt;.alias_sampling.swap -->\n<g id=\"edge12\" class=\"edge\">\n<title>.alias_sampling.qrom:out_l&#45;&gt;.alias_sampling.swap:In_target_0</title>\n<path fill=\"none\" stroke=\"black\" d=\"M372.12,-204.75C390.48,-204.75 390.48,-219.94 408.12,-225 497.11,-250.52 526.12,-236.26 613.61,-235.08\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"613.38,-238.58 623.36,-235.01 613.34,-231.58 613.38,-238.58\"/>\n</g>\n<!-- .alias_sampling.swap&#45;&gt;.alias_sampling.out_0 -->\n<g id=\"edge14\" class=\"edge\">\n<title>.alias_sampling.swap:out_target_0&#45;&gt;.alias_sampling.out_0</title>\n<path fill=\"none\" stroke=\"black\" d=\"M810.87,-235C821.91,-235 833.36,-238.29 843.4,-242.43\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"841.74,-245.52 852.29,-246.51 844.66,-239.15 841.74,-245.52\"/>\n</g>\n<!-- .alias_sampling.swap&#45;&gt;.alias_sampling.temp_1 -->\n<g id=\"edge15\" class=\"edge\">\n<title>.alias_sampling.swap:out_target_1&#45;&gt;.alias_sampling.temp_1</title>\n<path fill=\"none\" stroke=\"black\" d=\"M810.87,-212.75C820.42,-212.75 830.32,-210.39 839.35,-207.19\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"840.48,-210.51 848.45,-203.53 837.87,-204.01 840.48,-210.51\"/>\n</g>\n<!-- .alias_sampling.swap&#45;&gt;.alias_sampling.temp_3 -->\n<g id=\"edge13\" class=\"edge\">\n<title>.alias_sampling.swap:out_control&#45;&gt;.alias_sampling.temp_3</title>\n<path fill=\"none\" stroke=\"black\" d=\"M810.87,-257.25C816.61,-257.25 834.78,-278.36 850.09,-297.52\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"847.2,-299.52 856.14,-305.2 852.7,-295.18 847.2,-299.52\"/>\n</g>\n<!-- .alias_sampling.usp&#45;&gt;.alias_sampling.qrom -->\n<g id=\"edge16\" class=\"edge\">\n<title>.alias_sampling.usp:out&#45;&gt;.alias_sampling.qrom:In_l</title>\n<path fill=\"none\" stroke=\"black\" d=\"M181.62,-198.38C193.3,-198.38 198.4,-201.67 206.37,-203.52\"/>\n<polygon fill=\"black\" stroke=\"black\" points=\"205.8,-206.98 216.12,-204.59 206.56,-200.02 205.8,-206.98\"/>\n</g>\n</g>\n</svg>\n",
-      "text/plain": [
-       "<graphviz.graphs.Digraph at 0x105803fb0>"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 48
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "As we expected, the diagram displays five subroutines which are `usp`, `qrom`, `compare`, `had`, `swap`, and their hierarchical connections. Everything appears to be in order! Let's proceed with the compilation.\n",
-   "id": "2ee860fa5c451aad"
+   "id": "2ee860fa5c451aad",
+   "metadata": {},
+   "source": [
+    "As we expected, the diagram displays five subroutines which are `usp`, `qrom`, `compare`, `had`, `swap`, and their hierarchical connections. Everything appears to be in order! Let's proceed with the compilation.\n"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "5d0d2d69-4b77-4d62-9dd3-2405f4db21ed",
    "metadata": {
     "ExecuteTime": {
@@ -399,16 +654,16 @@
      "start_time": "2024-06-24T21:06:40.830608Z"
     }
    },
+   "outputs": [],
    "source": [
     "from bartiq.integrations import qref_to_bartiq\n",
     "\n",
     "uncompiled_routine = qref_to_bartiq(alias_sampling_qref)"
-   ],
-   "outputs": [],
-   "execution_count": 49
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "d20ef4d2-9420-4090-a402-ee5f27034524",
    "metadata": {
     "ExecuteTime": {
@@ -416,13 +671,21 @@
      "start_time": "2024-06-24T21:06:40.846589Z"
     }
    },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kjalowiecki/Projects/bartiq/src/bartiq/compilation/_compile.py:117: UserWarning: Found the following issues with the provided routine after the compilation has finished: [\"Symbol P_2 found in subroutine: alias_sampling.swap.passthrough_2, which is not among top level params: {'L', 'R', 'mu'}.\", \"Symbol P_1 found in subroutine: alias_sampling.swap.passthrough_1, which is not among top level params: {'L', 'R', 'mu'}.\", \"Symbol P_2 found in subroutine: alias_sampling.swap, which is not among top level params: {'L', 'R', 'mu'}.\"]\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "from bartiq import compile_routine\n",
     "\n",
     "compiled_routine = compile_routine(uncompiled_routine)"
-   ],
-   "outputs": [],
-   "execution_count": 50
+   ]
   },
   {
    "cell_type": "markdown",
@@ -434,6 +697,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "dad8df1e-9570-46c5-a422-4f29bba4d52c",
    "metadata": {
     "ExecuteTime": {
@@ -441,10 +705,6 @@
      "start_time": "2024-06-24T21:06:40.967739Z"
     }
    },
-   "source": [
-    "for resource in compiled_routine.resources.values():\n",
-    "    print(f\"{resource.name}: {resource.value}\")"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -455,7 +715,10 @@
      ]
     }
    ],
-   "execution_count": 51
+   "source": [
+    "for resource in compiled_routine.resources.values():\n",
+    "    print(f\"{resource.name}: {resource.value}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -476,6 +739,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "id": "becb2091-9faf-4364-ac22-f10240072937",
    "metadata": {
     "ExecuteTime": {
@@ -483,14 +747,6 @@
      "start_time": "2024-06-24T21:06:40.992467Z"
     }
    },
-   "source": [
-    "from bartiq import evaluate\n",
-    "\n",
-    "assignments = {\"L=120\", \"mu=8\"}\n",
-    "evaluated_routine = evaluate(compiled_routine, assignments)\n",
-    "for resource in evaluated_routine.resources.values():\n",
-    "    print(f\"{resource.name}: {resource.value}\")"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -501,7 +757,14 @@
      ]
     }
    ],
-   "execution_count": 52
+   "source": [
+    "from bartiq import evaluate\n",
+    "\n",
+    "assignments = {\"L=120\", \"mu=8\"}\n",
+    "evaluated_routine = evaluate(compiled_routine, assignments)\n",
+    "for resource in evaluated_routine.resources.values():\n",
+    "    print(f\"{resource.name}: {resource.value}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -518,6 +781,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "id": "dbf7d3a4-5a58-4dcb-990e-eccd0d7cda9a",
    "metadata": {
     "ExecuteTime": {
@@ -525,11 +789,6 @@
      "start_time": "2024-06-24T21:06:41.114669Z"
     }
    },
-   "source": [
-    "compiled_routine = compile_routine(uncompiled_routine, global_functions=[\"O\"])\n",
-    "for resource in compiled_routine.resources.values():\n",
-    "    print(f\"{resource.name}: {resource.value}\")"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -540,7 +799,11 @@
      ]
     }
    ],
-   "execution_count": 53
+   "source": [
+    "compiled_routine = compile_routine(uncompiled_routine, global_functions=[\"O\"])\n",
+    "for resource in compiled_routine.resources.values():\n",
+    "    print(f\"{resource.name}: {resource.value}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -552,6 +815,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "id": "2909fb37-6a15-44fc-a80f-46e562220fcb",
    "metadata": {
     "ExecuteTime": {
@@ -559,6 +823,16 @@
      "start_time": "2024-06-24T21:06:41.222791Z"
     }
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T_gates: 831\n",
+      "rotations: 2\n"
+     ]
+    }
+   ],
    "source": [
     "import math\n",
     "\n",
@@ -571,18 +845,7 @@
     "evaluated_routine = evaluate(compiled_routine, assignments, functions_map=functions_map)\n",
     "for resource in evaluated_routine.resources.values():\n",
     "    print(f\"{resource.name}: {resource.value}\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "T_gates: 831\n",
-      "rotations: 2\n"
-     ]
-    }
-   ],
-   "execution_count": 54
+   ]
   },
   {
    "cell_type": "markdown",
@@ -611,6 +874,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
    "id": "1a346534-4f97-4855-8262-2c5df824eb27",
    "metadata": {
     "ExecuteTime": {
@@ -618,29 +882,28 @@
      "start_time": "2024-06-24T21:06:41.372181Z"
     }
    },
-   "source": [
-    "from bartiq.integrations import explore_routine\n",
-    "\n",
-    "explore_routine(evaluated_routine)"
-   ],
    "outputs": [
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2026b27b761545808b9204edea7ff9e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
        "HBox(children=(_RoutineTree(multiple_selection=False, nodes=(Node(name='alias_sampling', nodes=(Node(name='com…"
-      ],
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "dbd90e9500c04d6894d2bff15b01a796"
-      }
+      ]
      },
-     "execution_count": 55,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 55
+   "source": [
+    "from bartiq.integrations import explore_routine\n",
+    "\n",
+    "explore_routine(evaluated_routine)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -652,28 +915,52 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
    "id": "a925abe0-9026-4079-9c5a-8ef5e087a551",
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\begin{align}\n",
+       "&\\text{Routine \\textrm{(alias\\_sampling)}}\\newline\n",
+       "&\\underline{\\text{Input ports:}}\\\\\n",
+       "&\\text{In\\_0} = R\\\\\n",
+       "&\\text{In\\_1} = 8\\\\\n",
+       "&\\text{In\\_2} = R\\\\\n",
+       "&\\text{In\\_3} = 8\\\\\n",
+       "&\\text{In\\_4} = 1\\newline\n",
+       "&\\underline{\\text{Output ports:}}\\\\\n",
+       "&\\text{out\\_0} = 7\\\\\n",
+       "&\\text{temp\\_0} = 8\\\\\n",
+       "&\\text{temp\\_1} = 7\\\\\n",
+       "&\\text{temp\\_2} = 8\\\\\n",
+       "&\\text{temp\\_3} = 1\\newline\n",
+       "&\\underline{\\text{Resources:}}\\\\\n",
+       "&T_{\\text{gates}} = 831\\\\\n",
+       "&rotations = 2\\\\\n",
+       "&\\text{usp}.\\!T_{\\text{gates}} = 320\\\\\n",
+       "&\\text{usp}.\\!rotations = 2\\\\\n",
+       "&\\text{qrom}.\\!T_{\\text{gates}} = 476\\\\\n",
+       "&\\text{compare}.\\!T_{\\text{gates}} = 28\\\\\n",
+       "&\\text{swap}.\\!T_{\\text{gates}} = 7\n",
+       "\\end{align}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from bartiq.integrations import routine_to_latex\n",
     "from IPython.display import Math\n",
     "\n",
     "Math(routine_to_latex(evaluated_routine))"
-   ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ],
-      "text/latex": "$\\displaystyle \\begin{align}\n&\\text{Routine \\textrm{(alias\\_sampling)}}\\newline\n&\\underline{\\text{Input ports:}}\\\\\n&\\text{In\\_0} = R\\\\\n&\\text{In\\_1} = 8\\\\\n&\\text{In\\_2} = R\\\\\n&\\text{In\\_3} = 8\\\\\n&\\text{In\\_4} = 1\\newline\n&\\underline{\\text{Output ports:}}\\\\\n&\\text{out\\_0} = R\\\\\n&\\text{temp\\_0} = 8\\\\\n&\\text{temp\\_1} = R\\\\\n&\\text{temp\\_2} = 8\\\\\n&\\text{temp\\_3} = 1\\newline\n&\\underline{\\text{Resources:}}\\\\\n&T_{\\text{gates}} = 831\\\\\n&rotations = 2\\\\\n&\\text{usp}.\\!T_{\\text{gates}} = 320\\\\\n&\\text{usp}.\\!rotations = 2\\\\\n&\\text{qrom}.\\!T_{\\text{gates}} = 476\\\\\n&\\text{compare}.\\!T_{\\text{gates}} = 28\\\\\n&\\text{swap}.\\!T_{\\text{gates}} = 7\n\\end{align}$"
-     },
-     "execution_count": 56,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 56
+   ]
   },
   {
    "cell_type": "markdown",
@@ -705,7 +992,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2694,13 +2694,13 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qref"
-version = "0.6.1"
+version = "0.6.2"
 description = "Quantum Resource Estimation Format"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "qref-0.6.1-py3-none-any.whl", hash = "sha256:464cf0d619010671bd511059e599ea2147e143a98c8269119196f914b1fc03cf"},
-    {file = "qref-0.6.1.tar.gz", hash = "sha256:bdc7dc2f52b2bffb553491eddfb131bd631d6f08116fd713addce596d4d294d5"},
+    {file = "qref-0.6.2-py3-none-any.whl", hash = "sha256:6d5d7ee81acae4d843e710ccd95a1fdcfcee3b5998fac855a1433ec6adaa2d04"},
+    {file = "qref-0.6.2.tar.gz", hash = "sha256:b58c7f32c7c63d70cae5163f450c5fc7eb01d4cc00ba1ea0650fa3ef500c2c30"},
 ]
 
 [package.dependencies]
@@ -3367,4 +3367,4 @@ jupyter = ["ipytree", "ipywidgets", "traitlets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "df50c0631bc8c4613343a5feaed53cc6c72656688872110de4c43a42e70aad48"
+content-hash = "5517a73d9fe4aad9079dd388f38b4c3807d220bbd991688c24b0af5098c0c07b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2694,13 +2694,13 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qref"
-version = "0.6.0"
+version = "0.6.1"
 description = "Quantum Resource Estimation Format"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "qref-0.6.0-py3-none-any.whl", hash = "sha256:723212c82ebf08be4b6158dd19c9b3cf6ce8d9d06534eab1121d3ef5bbc8a34f"},
-    {file = "qref-0.6.0.tar.gz", hash = "sha256:19bd643347d8e5793e6eee364210b40f79d1dfc2fe94a0bf90af04deb79206e9"},
+    {file = "qref-0.6.1-py3-none-any.whl", hash = "sha256:464cf0d619010671bd511059e599ea2147e143a98c8269119196f914b1fc03cf"},
+    {file = "qref-0.6.1.tar.gz", hash = "sha256:bdc7dc2f52b2bffb553491eddfb131bd631d6f08116fd713addce596d4d294d5"},
 ]
 
 [package.dependencies]
@@ -3367,4 +3367,4 @@ jupyter = ["ipytree", "ipywidgets", "traitlets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "dd64645fa0f7ed9a99bb54f3e52353629aa0dccd32953c8a66385f904c40452e"
+content-hash = "df50c0631bc8c4613343a5feaed53cc6c72656688872110de4c43a42e70aad48"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2694,13 +2694,13 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qref"
-version = "0.5.0"
+version = "0.6.0"
 description = "Quantum Resource Estimation Format"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "qref-0.5.0-py3-none-any.whl", hash = "sha256:7e7fd1117ac5ae05c5a7f14e3f86f45e4a9d8e2c9057a78ee7fa65b8ff5b8f39"},
-    {file = "qref-0.5.0.tar.gz", hash = "sha256:d0921d3bf08953cbdabbc8f475beec299252fe41d2d1708cbe44315bb916e537"},
+    {file = "qref-0.6.0-py3-none-any.whl", hash = "sha256:723212c82ebf08be4b6158dd19c9b3cf6ce8d9d06534eab1121d3ef5bbc8a34f"},
+    {file = "qref-0.6.0.tar.gz", hash = "sha256:19bd643347d8e5793e6eee364210b40f79d1dfc2fe94a0bf90af04deb79206e9"},
 ]
 
 [package.dependencies]
@@ -3367,4 +3367,4 @@ jupyter = ["ipytree", "ipywidgets", "traitlets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "15574b6e4c72cde9b438efc39e6c9474338bd963a321c2dee1741cdb65b18793"
+content-hash = "dd64645fa0f7ed9a99bb54f3e52353629aa0dccd32953c8a66385f904c40452e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.9"
 pydantic = "^2.7"
 sympy = "^1.12"
 pyparsing ="~3.1.2"
-qref = "0.6.1"
+qref = "0.6.2"
 
 # A list of all of the optional dependencies, some of which are included in the
 # below `extras`. They can be opted into by apps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.9"
 pydantic = "^2.7"
 sympy = "^1.12"
 pyparsing ="~3.1.2"
-qref = "0.6.0"
+qref = "0.6.1"
 
 # A list of all of the optional dependencies, some of which are included in the
 # below `extras`. They can be opted into by apps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.9"
 pydantic = "^2.7"
 sympy = "^1.12"
 pyparsing ="~3.1.2"
-qref = "0.5.0"
+qref = "0.6.0"
 
 # A list of all of the optional dependencies, some of which are included in the
 # below `extras`. They can be opted into by apps.

--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -217,7 +217,7 @@ class Routine(BaseModel):
     connections: list[Connection] = Field(default_factory=list)
     resources: dict[str, Resource] = Field(default_factory=dict)
     input_params: Sequence[Symbol] = Field(default_factory=list)
-    local_variables: list[str] = Field(default_factory=list)
+    local_variables: dict[str, str] = Field(default_factory=dict)
     linked_params: dict[Symbol, list[tuple[str, Symbol]]] = Field(default_factory=dict)
     meta: Optional[dict[str, Any]] = Field(default_factory=dict)
 

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -433,7 +433,7 @@ def _compile_routine_with_functions(
 
     routine.symbolic_function = None
     for subroutine in routine.walk():
-        subroutine.local_variables = []
+        subroutine.local_variables = {}
 
     return routine
 

--- a/src/bartiq/compilation/_symbolic_function.py
+++ b/src/bartiq/compilation/_symbolic_function.py
@@ -166,11 +166,6 @@ def parse_output_expressions(
     return [DependentVariable(key, backend.as_expression(value), backend) for key, value in output_expressions.items()]
 
 
-def parse_output_expression(output_expression: str, backend: SymbolicBackend[T_expr]) -> DependentVariable[T_expr]:
-    """Parses a single output expression string to an output variable."""
-    return DependentVariable.from_str(output_expression, backend)
-
-
 def _merge_functions(
     function_1: SymbolicFunction[T_expr], function_2: SymbolicFunction[T_expr]
 ) -> SymbolicFunction[T_expr]:
@@ -213,12 +208,6 @@ def _merge_functions(
         outputs_new[output_1_symbol] = output_1_variable
 
     return SymbolicFunction(inputs_new, outputs_new)
-
-
-def _serialize_variables(variables: Union[dict[str, IndependentVariable], dict[str, DependentVariable]]) -> list[str]:
-    """Serializes variables."""
-    assert isinstance(variables, dict)
-    return [str(variable) for variable in variables.values()]
 
 
 def _verify_symbolic_function(function: SymbolicFunction) -> None:

--- a/src/bartiq/compilation/_symbolic_function.py
+++ b/src/bartiq/compilation/_symbolic_function.py
@@ -86,8 +86,8 @@ class SymbolicFunction(Generic[T_expr]):
     # def from_str(cls: Type[T], ...) -> T[T_expr]
     # But TypeVars cannot have arguments.
     @classmethod
-    def from_str(
-        cls, inputs: list[str], outputs: list[str], backend: SymbolicBackend[T_expr]
+    def assemble(
+        cls, inputs: list[str], outputs: dict[str, str], backend: SymbolicBackend[T_expr]
     ) -> SymbolicFunction[T_expr]:
         """Creates a SymbolicFunction instance from lists of easy-to-write strings.
 
@@ -100,9 +100,12 @@ class SymbolicFunction(Generic[T_expr]):
         """
         return cls(_parse_input_expressions(inputs), parse_output_expressions(outputs, backend))
 
-    def to_str(self) -> tuple[list[str], list[str]]:
+    def to_str(self) -> tuple[list[str], dict[str, str]]:
         """Serialises the SymbolicFunction to a string (in the format required by ``from_str``)."""
-        return (_serialize_variables(self.inputs), _serialize_variables(self.outputs))
+        return (
+            [var.symbol for var in self.inputs.values()],
+            {var.symbol: str(var.expression) for var in self.outputs.values()},
+        )
 
     def __repr__(self) -> str:
         inputs = list(self._inputs.values())
@@ -160,7 +163,7 @@ def parse_output_expressions(
     output_expressions: list[str], backend: SymbolicBackend[T_expr]
 ) -> list[DependentVariable[T_expr]]:
     """Parses a list of output expressions to a dictionary mapping output symbols to their expressions."""
-    return [parse_output_expression(output_expression, backend) for output_expression in output_expressions]
+    return [DependentVariable(key, backend.as_expression(value), backend) for key, value in output_expressions.items()]
 
 
 def parse_output_expression(output_expression: str, backend: SymbolicBackend[T_expr]) -> DependentVariable[T_expr]:
@@ -569,7 +572,7 @@ def _make_cost_variables(
     """Compiles a cost variable, taking into account any local parameters."""
     # This allows users to reuse costs in subsequent expressions.
     known_params = {local_param.symbol: local_param for local_param in local_params}
-    costs = _resources_to_cost_expressions(resources)
+    costs = {resource.name: resource.value for resource in resources}
     new_cost_variables = []
     for old_output_variable in parse_output_expressions(costs, backend):
         # Substitute any local parameters
@@ -587,13 +590,6 @@ def _make_cost_variables(
     return new_cost_variables
 
 
-def _resources_to_cost_expressions(resources: list[Resource]) -> list[str]:
-    expressions = []
-    for resource in resources:
-        expressions.append(f"{resource.name} = {resource.value}")
-    return expressions
-
-
 def _make_output_register_size_variables(
     output_ports: dict[str, Port],
     local_params: list[DependentVariable[T_expr]],
@@ -602,14 +598,14 @@ def _make_output_register_size_variables(
     """Compiles an output register size variables, taking into account any local parameters."""
     output_register_sizes = {key: port.size for key, port in output_ports.items() if port.size is not None}
 
-    output_expression_strs = [
-        f"{_get_output_name(output)} = {expression_str}" for output, expression_str in output_register_sizes.items()
-    ]
+    output_expression_map = {
+        _get_output_name(output): expression_str for output, expression_str in output_register_sizes.items()
+    }
     # Next, substitute in any local params
     known_params = {local_param.symbol: local_param for local_param in local_params}
     return [
         _substitute_local_parameters(output, known_params)
-        for output in parse_output_expressions(output_expression_strs, backend)
+        for output in parse_output_expressions(output_expression_map, backend)
     ]
 
 
@@ -631,16 +627,13 @@ def _make_input_register_size_variables(
     """
     input_register_sizes = {key: port.size for key, port in input_ports.items() if port.size is not None}
     # First, remove all the #in_ prefixes to get the corresponding output variables
-    output_expression_strs = [
-        f"{input} = {expression_str}"
-        for input, expression_str in _get_non_trivial_input_register_sizes(input_register_sizes).items()
-    ]
+    output_expression_map = _get_non_trivial_input_register_sizes(input_register_sizes)
 
     # Next, substitute in any local params
     known_params = {local_param.symbol: local_param for local_param in local_params}
     return [
         _substitute_local_parameters(output, known_params)
-        for output in parse_output_expressions(output_expression_strs, backend)
+        for output in parse_output_expressions(output_expression_map, backend)
     ]
 
 
@@ -666,12 +659,12 @@ def _make_input_register_constants(
     """Identifies constant input register sizes and formats them as output variables."""
     input_register_sizes = {key: port.size for key, port in input_ports.items() if port.size is not None}
 
-    output_expression_strs = [
-        f"#{inpt} = {expression_str}"
+    output_expressions = {
+        f"#{inpt}": expression_str
         for inpt, expression_str in input_register_sizes.items()
         if is_constant_int(expression_str)
-    ]
-    return parse_output_expressions(output_expression_strs, backend)
+    }
+    return parse_output_expressions(output_expressions, backend)
 
 
 def _substitute_local_parameters(output_variable, local_params):

--- a/src/bartiq/compilation/_symbolic_function.py
+++ b/src/bartiq/compilation/_symbolic_function.py
@@ -160,7 +160,7 @@ def _parse_input_expressions(inputs: list[str]) -> list[IndependentVariable]:
 
 
 def parse_output_expressions(
-    output_expressions: list[str], backend: SymbolicBackend[T_expr]
+    output_expressions: dict[str, str], backend: SymbolicBackend[T_expr]
 ) -> list[DependentVariable[T_expr]]:
     """Parses a list of output expressions to a dictionary mapping output symbols to their expressions."""
     return [DependentVariable(key, backend.as_expression(value), backend) for key, value in output_expressions.items()]
@@ -561,7 +561,7 @@ def _make_cost_variables(
     """Compiles a cost variable, taking into account any local parameters."""
     # This allows users to reuse costs in subsequent expressions.
     known_params = {local_param.symbol: local_param for local_param in local_params}
-    costs = {resource.name: resource.value for resource in resources}
+    costs = {resource.name: str(resource.value) for resource in resources}
     new_cost_variables = []
     for old_output_variable in parse_output_expressions(costs, backend):
         # Substitute any local parameters
@@ -585,7 +585,7 @@ def _make_output_register_size_variables(
     backend: SymbolicBackend[T_expr],
 ) -> list[DependentVariable[T_expr]]:
     """Compiles an output register size variables, taking into account any local parameters."""
-    output_register_sizes = {key: port.size for key, port in output_ports.items() if port.size is not None}
+    output_register_sizes = {key: str(port.size) for key, port in output_ports.items() if port.size is not None}
 
     output_expression_map = {
         _get_output_name(output): expression_str for output, expression_str in output_register_sizes.items()
@@ -646,7 +646,7 @@ def _make_input_register_constants(
     input_ports: dict[str, Port], backend: SymbolicBackend[T_expr]
 ) -> list[DependentVariable[T_expr]]:
     """Identifies constant input register sizes and formats them as output variables."""
-    input_register_sizes = {key: port.size for key, port in input_ports.items() if port.size is not None}
+    input_register_sizes = {key: str(port.size) for key, port in input_ports.items() if port.size is not None}
 
     output_expressions = {
         f"#{inpt}": expression_str

--- a/src/bartiq/integrations/latex.py
+++ b/src/bartiq/integrations/latex.py
@@ -15,7 +15,6 @@
 from sympy import latex, symbols
 
 from .._routine import Routine
-from ..compilation._utilities import split_equation
 from ..symbolics.sympy_interpreter import parse_to_sympy
 
 
@@ -82,10 +81,10 @@ def _format_port_sizes(ports, label):
 
 def _format_local_variables(local_variables):
     """Formats routine's local variables to LaTeX."""
-    lines = []
-    for variable in local_variables:
-        assignment, expression = split_equation(variable)
-        lines.append(f"&{_format_param_math(assignment)} = {_latex_expression(expression)}")
+    lines = [
+        f"&{_format_param_math(symbol)} = {_latex_expression(expression)}"
+        for symbol, expression in local_variables.items()
+    ]
     return _format_section_multi_line("Local variables", lines)
 
 

--- a/src/bartiq/integrations/qref.py
+++ b/src/bartiq/integrations/qref.py
@@ -71,7 +71,7 @@ def _bartiq_routine_to_qref_v1_dict(routine: Routine) -> dict:
             for connection in routine.connections
         ],
         "input_params": [str(symbol) for symbol in routine.input_params],
-        "local_variables": [str(symbol) for symbol in routine.local_variables],
+        "local_variables": {var: expr for var, expr in routine.local_variables.items()},
         "linked_params": [
             {
                 "source": str(source),

--- a/src/bartiq/symbolics/utilities.py
+++ b/src/bartiq/symbolics/utilities.py
@@ -32,21 +32,18 @@ def _split_equation(equation: str) -> tuple[str, str]:
 
 def infer_subresources(routine: Routine, backend):
     """Infer what are the resources of a routine's children."""
-    expressions = [resource.value for resource in routine.resources.values()]
-    for variable in routine.local_variables:
-        _, rhs = _split_equation(variable)
-        expressions.append(rhs)
+    expressions = [*[resource.value for resource in routine.resources.values()], *routine.local_variables.values()]
 
     # Any path-prefixed variable (i.e. prefixed by a .-separated path) not
     # in subresources, but found in the RHS of an expression in either costs,
     # local_variables, or output ports.
-    subresources = []
-    for expr in expressions:
-        vars = _extract_input_variables_from_expression(expr, backend)
+    subresources = [
+        var
+        for expr in expressions
+        for var in _extract_input_variables_from_expression(expr, backend)
         # Only consider variables that are subresources (ones that have a "." in the name).
-        for var in vars:
-            if "." in var:
-                subresources.append(var)
+        if "." in var
+    ]
     return sorted(set(subresources))
 
 

--- a/src/bartiq/symbolics/utilities.py
+++ b/src/bartiq/symbolics/utilities.py
@@ -15,21 +15,6 @@
 from .. import Routine
 
 
-def _split_equation(equation: str) -> tuple[str, str]:
-    """Splits an equation string and returns the left and right side."""
-    if equation.count("=") != 1:
-        raise ValueError(f"Equations must contain a single equals sign; found {equation}")
-
-    lhs, rhs = equation.split("=")
-    lhs = lhs.strip()
-    rhs = rhs.strip()
-
-    if not lhs or not rhs:
-        raise ValueError(f"Equations must have both a left- and right-hand side; found {equation}")
-
-    return (lhs, rhs)
-
-
 def infer_subresources(routine: Routine, backend):
     """Infer what are the resources of a routine's children."""
     expressions = [*[resource.value for resource in routine.resources.values()], *routine.local_variables.values()]

--- a/src/bartiq/verification.py
+++ b/src/bartiq/verification.py
@@ -104,9 +104,9 @@ def _verify_expressions_parsable(routine: Routine, backend: SymbolicBackend) -> 
         ]
         local_variable_problems = [
             _verify_expression(
-                backend, local_variable, local_variable.split("=")[1], "local_variable", subroutine.absolute_path()
+                backend, f"{variable} = {expression}", expression, "local_variable", subroutine.absolute_path()
             )
-            for local_variable in subroutine.local_variables
+            for variable, expression in subroutine.local_variables.items()
         ]
         port_problems = [
             _verify_expression(backend, port, port.size, "port size", subroutine.absolute_path())

--- a/tests/compilation/data/compile_test_data.yaml
+++ b/tests/compilation/data/compile_test_data.yaml
@@ -648,7 +648,7 @@
                 type: other
                 value: {type: str, value: k}
             input_params: [x, y]
-            local_variables: [i = x + y, j = x - y, k = (i + j) / 2 + (i - j) / 2]
+            local_variables: {"i": "x + y", "j": "x - y", "k": "(i + j) / 2 + (i - j) / 2"}
           b:
             name: b
             type: null
@@ -658,7 +658,7 @@
                 type: other
                 value: {type: str, value: k}
             input_params: [x, y]
-            local_variables: [i = x + y, j = x - y, k = (i + j) / 2 + (i - j) / 2]
+            local_variables: {"i": "x + y", "j": "x - y", "k": "(i + j) / 2 + (i - j) / 2"}
         resources:
           z:
             name: z
@@ -677,7 +677,7 @@
                 type: other
                 value: {type: str, value: k}
             input_params: [x, y]
-            local_variables: [i = x + y, j = x - y, k = (i + j) / 2 + (i - j) / 2]
+            local_variables: {"i": "x + y", "j": "x - y", "k": "(i + j) / 2 + (i - j) / 2"}
           b:
             name: b
             type: null
@@ -687,7 +687,7 @@
                 type: other
                 value: {type: str, value: k}
             input_params: [x, y]
-            local_variables: [i = x + y, j = x - y, k = (i + j) / 2 + (i - j) / 2]
+            local_variables: {"i": "x + y", "j": "x - y", "k": "(i + j) / 2 + (i - j) / 2"}
         resources:
           z:
             name: z
@@ -827,7 +827,7 @@
         name: z
         type: other
         value: {type: str, value: 3 * M}
-    local_variables: [M = 2 * N]
+    local_variables: {"M": "2 * N"}
   - name: root
     type: null
     ports:

--- a/tests/compilation/data/evaluate_test_data.yaml
+++ b/tests/compilation/data/evaluate_test_data.yaml
@@ -929,13 +929,13 @@
 - - name: root
     type: null
     input_params: [L]
-    local_variables: ['N=L/multiplicity(2,L)']
+    local_variables: {'N': 'L/multiplicity(2,L)'}
     resources:
       T_gates: {name: T_gates, type: additive, value: 8*ceiling(log_2(N))}
   - [L = 10]
   - name: root
     type: null
-    local_variables: ['N=L/multiplicity(2,L)']
+    local_variables: {'N': 'L/multiplicity(2,L)'}
     resources:
       T_gates: {name: T_gates, type: additive, value: '32'}
 # Linked params through multiple generations

--- a/tests/compilation/test_compile.py
+++ b/tests/compilation/test_compile.py
@@ -62,25 +62,25 @@ def f_3_optional_inputs(a, b=2, c=3):
 DEFINED_EXPRESSION_FUNCTIONS_TEST_DATA = [
     # Testing function which can be interpreted symbolically
     (
-        SymbolicFunction.from_str(["a", "b"], ["x = f(a) + f(b)"], BACKEND),
+        SymbolicFunction.assemble(["a", "b"], {"x": "f(a) + f(b)"}, BACKEND),
         {"f": f_1_simple},
         {"x": "a + b + 2"},
     ),
     # Testing function which cannot be interpreted symbolically due to having a condition
     (
-        SymbolicFunction.from_str(["a"], ["x = f(a) + a"], BACKEND),
+        SymbolicFunction.assemble(["a"], {"x": "f(a) + a"}, BACKEND),
         {"f": f_2_conditional},
         {"x": "a + f(a)"},
     ),
     # Testing function with multiple inputs, some with default values ["x = a**2 + 2*a + 3*b"]
     (
-        SymbolicFunction.from_str(["a", "b"], ["x = f(a, b) + f(a, a, a)"], BACKEND),
+        SymbolicFunction.assemble(["a", "b"], {"x": "f(a, b) + f(a, a, a)"}, BACKEND),
         {"f": f_3_optional_inputs},
         {"x": "a ^ 2 + 2*a + 3*b"},
     ),
     # Testing nested calls of a simple function
     (
-        SymbolicFunction.from_str(["a"], ["x = f(f(f(a)))"], BACKEND),
+        SymbolicFunction.assemble(["a"], {"x": "f(f(f(a)))"}, BACKEND),
         {"f": f_1_simple},
         {"x": "a + 3"},
     ),
@@ -106,7 +106,7 @@ def mad_max(a, b):
     "function, functions_map, expected_error",
     [
         (
-            SymbolicFunction.from_str(["a", "b"], ["x = max(a, b)"], BACKEND),
+            SymbolicFunction.assemble(["a", "b"], {"x": "max(a, b)"}, BACKEND),
             {"max": mad_max},
             "Attempted to redefine built-in function max",
         )

--- a/tests/compilation/test_core.py
+++ b/tests/compilation/test_core.py
@@ -20,7 +20,6 @@ from bartiq.compilation._symbolic_function import (
     SymbolicFunction,
     _get_renamed_inputs_and_outputs,
     _merge_functions,
-    _serialize_variables,
     compile_functions,
     rename_variables,
 )
@@ -36,14 +35,14 @@ FROM_STR_TEST_CASES = [
     # Null case
     (
         [],  # Inputs
-        [],  # Outputs
+        {},  # Outputs
         {},  # Expected inputs
         {},  # Expected outputs
     ),
     # Input-only case
     (
         ["a", "b", "c"],  # Inputs
-        [],  # Outputs
+        {},  # Outputs
         {  # Expected inputs
             "a": IndependentVariable("a"),
             "b": IndependentVariable("b"),
@@ -54,7 +53,7 @@ FROM_STR_TEST_CASES = [
     # Output-only case
     (
         [],  # Inputs
-        ["a = 1", "b = 2"],  # Outputs
+        {"a": "1", "b": "2"},  # Outputs
         {},  # Expected inputs
         {  # Expected outputs
             "a": "a = 1",
@@ -64,7 +63,7 @@ FROM_STR_TEST_CASES = [
     # Full case
     (
         ["x", "y"],  # Inputs
-        ["a = x + y", "b = x - y"],  # Outputs
+        {"a": "x + y", "b": "x - y"},  # Outputs
         {  # Expected inputs
             "x": IndependentVariable("x"),
             "y": IndependentVariable("y"),
@@ -78,9 +77,9 @@ FROM_STR_TEST_CASES = [
 
 
 @pytest.mark.parametrize("inputs, outputs, expected_inputs, expected_outputs", FROM_STR_TEST_CASES)
-def test_SymbolicFunction_from_str(inputs, outputs, expected_inputs, expected_outputs, backend):
+def test_SymbolicFunction_assemble(inputs, outputs, expected_inputs, expected_outputs, backend):
     expected_outputs = {k: DependentVariable.from_str(v, backend) for k, v in expected_outputs.items()}
-    function = SymbolicFunction.from_str(inputs, outputs, backend)
+    function = SymbolicFunction.assemble(inputs, outputs, backend)
     assert function.inputs == expected_inputs
     assert function.outputs == expected_outputs
 
@@ -93,157 +92,155 @@ def test_SymbolicFunction_from_str(inputs, outputs, expected_inputs, expected_ou
 EQUALITY_TEST_CASES = [
     # Null case
     (
-        ([], []),
-        ([], []),
+        ([], {}),
+        ([], {}),
     ),
     # Permuted inputs
     (
-        (["a", "b"], []),
-        (["b", "a"], []),
+        (["a", "b"], {}),
+        (["b", "a"], {}),
     ),
     # Permuted outputs
     (
-        ([], ["a = 42", "b = 24"]),
-        ([], ["b = 24", "a = 42"]),
+        ([], {"a": "42", "b": "24"}),
+        ([], {"b": "24", "a": "42"}),
     ),
     # Permuted inputs and outputs
     (
-        (["a", "b"], ["c = a", "d = b"]),
-        (["b", "a"], ["d = b", "c = a"]),
+        (["a", "b"], {"c": "a", "d": "b"}),
+        (["b", "a"], {"d": "b", "c": "a"}),
     ),
     # Addition vs multiplication
     (
-        (["a"], ["b = a + a"]),
-        (["a"], ["b = 2 * a"]),
+        (["a"], {"b": "a + a"}),
+        (["a"], {"b": "2 * a"}),
     ),
 ]
 
 
 @pytest.mark.parametrize("function_1, function_2", EQUALITY_TEST_CASES)
 def test_SymbolicFunction_equality(function_1, function_2, backend):
-    function_1 = SymbolicFunction.from_str(*function_1, backend)
-    function_2 = SymbolicFunction.from_str(*function_2, backend)
+    function_1 = SymbolicFunction.assemble(*function_1, backend)
+    function_2 = SymbolicFunction.assemble(*function_2, backend)
 
     assert function_1 == function_2
 
 
 ERRORS_TEST_CASES = [
     # Output references unknown variables
-    (([], ["b = a"]), BartiqCompilationError, "Expressions must not contain unknown variables"),
+    (([], {"b": "a"}), BartiqCompilationError, "Expressions must not contain unknown variables"),
     # No duplicate inputs
-    ((["a", "a"], []), BartiqCompilationError, "Variable list contains repeated symbol"),
-    # No duplicate outputs
-    (([], ["a = 0", "a = 1"]), BartiqCompilationError, "Variable list contains repeated symbol"),
+    ((["a", "a"], {}), BartiqCompilationError, "Variable list contains repeated symbol"),
     # Outputs cannot share names with inputs
-    ((["a"], ["a = 0"]), BartiqCompilationError, "Outputs must not reuse input symbols"),
+    ((["a"], {"a": "0"}), BartiqCompilationError, "Outputs must not reuse input symbols"),
 ]
 
 
 @pytest.mark.parametrize("function, exception, match", ERRORS_TEST_CASES)
 def test_SymbolicFunction_errors(function, exception, match, backend):
     with pytest.raises(exception, match=match):
-        SymbolicFunction.from_str(*function, backend)
+        SymbolicFunction.assemble(*function, backend)
 
 
 MERGE_FUNCTIONS_TEST_CASES = [
     # Null case
     (
-        ([], []),
-        ([], []),
-        ([], []),
+        ([], {}),
+        ([], {}),
+        ([], {}),
     ),
     # Constant function from two unconnected functions
     (
-        (["a"], []),
-        ([], ["b = 42"]),
-        (["a"], ["b = 42"]),
+        (["a"], {}),
+        ([], {"b": "42"}),
+        (["a"], {"b": "42"}),
     ),
     # Constant function from connected functions
     (
-        (["a"], ["b = a + 1"]),
-        (["b"], ["c = 42"]),
-        (["a"], ["c = 42"]),
+        (["a"], {"b": "a + 1"}),
+        (["b"], {"c": "42"}),
+        (["a"], {"c": "42"}),
     ),
     #  Null outer function from non-null functions
     (
-        ([], ["a = 42"]),
-        (["a"], []),
-        ([], []),
+        ([], {"a": "42"}),
+        (["a"], {}),
+        ([], {}),
     ),
     # Trivial case 1
     (
-        (["a"], ["b = a"]),
-        ([], []),
-        (["a"], ["b = a"]),
+        (["a"], {"b": "a"}),
+        ([], {}),
+        (["a"], {"b": "a"}),
     ),
     # Trivial case 2
     (
-        ([], []),
-        (["a"], ["b = a"]),
-        (["a"], ["b = a"]),
+        ([], {}),
+        (["a"], {"b": "a"}),
+        (["a"], {"b": "a"}),
     ),
     # Simple linear case
     (
-        (["a"], ["b = a"]),
-        (["b"], ["c = b"]),
-        (["a"], ["c = a"]),
+        (["a"], {"b": "a"}),
+        (["b"], {"c": "b"}),
+        (["a"], {"c": "a"}),
     ),
     # Tensor of two functions
     (
-        (["a"], ["b = a + 1"]),
-        (["c"], ["d = c + 2"]),
-        (["a", "c"], ["b = a + 1", "d = c + 2"]),
+        (["a"], {"b": "a + 1"}),
+        (["c"], {"d": "c + 2"}),
+        (["a", "c"], {"b": "a + 1", "d": "c + 2"}),
     ),
     # Simple single-variable addition
     (
-        (["x"], ["y = x + 1"]),
-        (["y"], ["z = y + 1"]),
-        (["x"], ["z = x + 2"]),
+        (["x"], {"y": "x + 1"}),
+        (["y"], {"z": "y + 1"}),
+        (["x"], {"z": "x + 2"}),
     ),
     # Nested functions
     (
-        (["x"], ["y = f(x)"]),
-        (["y"], ["z = g(y)"]),
-        (["x"], ["z = g(f(x))"]),
+        (["x"], {"y": "f(x)"}),
+        (["y"], {"z": "g(y)"}),
+        (["x"], {"z": "g(f(x))"}),
     ),
     # Both functions introduce new variables
     (
-        (["a", "b"], ["c = a + b"]),
-        (["c", "d"], ["e = c + d"]),
-        (["a", "b", "d"], ["e = a + b + d"]),
+        (["a", "b"], {"c": "a + b"}),
+        (["c", "d"], {"e": "c + d"}),
+        (["a", "b", "d"], {"e": "a + b + d"}),
     ),
     # Both functions define outputs
     (
-        (["a"], ["b = f(a)", "c = g(a)"]),
-        (["b"], ["d = h(b)"]),
-        (["a"], ["c = g(a)", "d = h(f(a))"]),
+        (["a"], {"b": "f(a)", "c": "g(a)"}),
+        (["b"], {"d": "h(b)"}),
+        (["a"], {"c": "g(a)", "d": "h(f(a))"}),
     ),
     # Automatic simplification (woooooahhh!)
     (
-        (["x"], ["y = log(x)"]),
-        (["y"], ["z = exp(y)"]),
-        (["x"], ["z = x"]),
+        (["x"], {"y": "log(x)"}),
+        (["y"], {"z": "exp(y)"}),
+        (["x"], {"z": "x"}),
     ),
     # Allow for merged functions to take same inputs
     (
-        (["x"], []),
-        (["x"], []),
-        (["x"], []),
+        (["x"], {}),
+        (["x"], {}),
+        (["x"], {}),
     ),
     # Allow for merged functions to take same outputs if they have the same expressions
     (
-        ([], ["x = 0"]),
-        ([], ["x = 0"]),
-        ([], ["x = 0"]),
+        ([], {"x": "0"}),
+        ([], {"x": "0"}),
+        ([], {"x": "0"}),
     ),
 ]
 
 
 @pytest.mark.parametrize("base_func, target_func, expected_func", MERGE_FUNCTIONS_TEST_CASES)
 def test_merge_functions(base_func, target_func, expected_func, backend):
-    base_func = SymbolicFunction.from_str(*base_func, backend)
-    target_func = SymbolicFunction.from_str(*target_func, backend)
-    expected_func = SymbolicFunction.from_str(*expected_func, backend)
+    base_func = SymbolicFunction.assemble(*base_func, backend)
+    target_func = SymbolicFunction.assemble(*target_func, backend)
+    expected_func = SymbolicFunction.assemble(*expected_func, backend)
 
     assert _merge_functions(base_func, target_func) == expected_func
 
@@ -251,14 +248,14 @@ def test_merge_functions(base_func, target_func, expected_func, backend):
 MERGE_FUNCTION_ERRORS_TEST_CASES = [
     # Target function has output already defined as base input
     (
-        (["y"], ["z = g(y)"]),
-        (["x"], ["y = f(x)"]),
+        (["y"], {"z": "g(y)"}),
+        (["x"], {"y": "f(x)"}),
         "Target function outputs must not reference base function inputs when merging",
     ),
     # Functions have same output symbols, but different expressions
     (
-        ([], ["x = 1"]),
-        ([], ["x = 0"]),
+        ([], {"x": "1"}),
+        ([], {"x": "0"}),
         "Merging functions may only have same outputs if the outputs share the same expression",
     ),
 ]
@@ -266,8 +263,8 @@ MERGE_FUNCTION_ERRORS_TEST_CASES = [
 
 @pytest.mark.parametrize("base_func, target_func, match", MERGE_FUNCTION_ERRORS_TEST_CASES)
 def test_merge_functions_errors(base_func, target_func, match, backend):
-    base_func = SymbolicFunction.from_str(*base_func, backend)
-    target_func = SymbolicFunction.from_str(*target_func, backend)
+    base_func = SymbolicFunction.assemble(*base_func, backend)
+    target_func = SymbolicFunction.assemble(*target_func, backend)
 
     with pytest.raises(BartiqCompilationError, match=match):
         _merge_functions(base_func, target_func)
@@ -277,55 +274,55 @@ COMPILE_FUNCTIONS_TEST_CASES = [
     # Null case
     (
         [],
-        ([], []),
+        ([], {}),
     ),
     # Nuller case
     (
         [
-            ([], []),
+            ([], {}),
         ],
-        ([], []),
+        ([], {}),
     ),
     # Nullest case
     (
         [
-            ([], []),
-            ([], []),
+            ([], {}),
+            ([], {}),
         ],
-        ([], []),
+        ([], {}),
     ),
     # The "Dude, I heard you like functions..." case
     (
         [
-            (["a"], ["b = f(a)"]),
-            (["b"], ["c = g(b)"]),
-            (["c"], ["d = h(c)"]),
+            (["a"], {"b": "f(a)"}),
+            (["b"], {"c": "g(b)"}),
+            (["c"], {"d": "h(c)"}),
         ],
-        (["a"], ["d = h(g(f(a)))"]),
+        (["a"], {"d": "h(g(f(a)))"}),
     ),
     # Expanding outputs case (via generating binary number additions)
     (
         [
-            (["a"], ["b0 = a + 0", "b1 = a + 1"]),
-            (["b0"], ["c00 = b0 + 0", "c10 = b0 + 2"]),
-            (["b1"], ["c01 = b1 + 0", "c11 = b1 + 2"]),
+            (["a"], {"b0": "a + 0", "b1": "a + 1"}),
+            (["b0"], {"c00": "b0 + 0", "c10": "b0 + 2"}),
+            (["b1"], {"c01": "b1 + 0", "c11": "b1 + 2"}),
         ],
-        (["a"], ["c00 = a + 0", "c01 = a + 1", "c10 = a + 2", "c11 = a + 3"]),
+        (["a"], {"c00": "a + 0", "c01": "a + 1", "c10": "a + 2", "c11": "a + 3"}),
     ),
     # Decreasing inputs case (via log-tree adder)
     (
         [
-            (["a000", "a001"], ["b00 = a000 + a001"]),
-            (["a010", "a011"], ["b01 = a010 + a011"]),
-            (["a100", "a101"], ["b10 = a100 + a101"]),
-            (["a110", "a111"], ["b11 = a110 + a111"]),
-            (["b00", "b01"], ["c0 = b00 + b01"]),
-            (["b10", "b11"], ["c1 = b10 + b11"]),
-            (["c0", "c1"], ["d = c0 + c1"]),
+            (["a000", "a001"], {"b00": "a000 + a001"}),
+            (["a010", "a011"], {"b01": "a010 + a011"}),
+            (["a100", "a101"], {"b10": "a100 + a101"}),
+            (["a110", "a111"], {"b11": "a110 + a111"}),
+            (["b00", "b01"], {"c0": "b00 + b01"}),
+            (["b10", "b11"], {"c1": "b10 + b11"}),
+            (["c0", "c1"], {"d": "c0 + c1"}),
         ],
         (
             ["a000", "a001", "a010", "a011", "a100", "a101", "a110", "a111"],
-            ["d = a000 + a001 + a010 + a011 + a100 + a101 + a110 + a111"],
+            {"d": "a000 + a001 + a010 + a011 + a100 + a101 + a110 + a111"},
         ),
     ),
 ]
@@ -333,8 +330,8 @@ COMPILE_FUNCTIONS_TEST_CASES = [
 
 @pytest.mark.parametrize("functions, expected_function", COMPILE_FUNCTIONS_TEST_CASES)
 def test_compile_functions(functions, expected_function, backend):
-    functions = list(map(lambda func: SymbolicFunction.from_str(*func, backend), functions))
-    expected_function = SymbolicFunction.from_str(*expected_function, backend)
+    functions = list(map(lambda func: SymbolicFunction.assemble(*func, backend), functions))
+    expected_function = SymbolicFunction.assemble(*expected_function, backend)
 
     assert compile_functions(functions) == expected_function
 
@@ -342,35 +339,35 @@ def test_compile_functions(functions, expected_function, backend):
 RENAME_VARIABLES_TEST_CASES = [
     # Null case
     (
-        ([], []),
+        ([], {}),
         {},
-        ([], []),
+        ([], {}),
     ),
     # Renaming inputs
     (
-        (["a", "b", "c"], []),
+        (["a", "b", "c"], {}),
         {"a": "x", "c": "y"},
-        (["x", "b", "y"], []),
+        (["x", "b", "y"], {}),
     ),
     # Renaming outputs
     (
-        ([], ["a = 42", "b = 3.141", "c = 101"]),
+        ([], {"a": "42", "b": "3.141", "c": "101"}),
         {"a": "x", "c": "y"},
-        ([], ["x = 42", "b = 3.141", "y = 101"]),
+        ([], {"x": "42", "b": "3.141", "y": "101"}),
     ),
     # Renaming inputs and outputs
     (
-        (["a", "b", "c"], ["d = a + b", "e = b + c"]),
+        (["a", "b", "c"], {"d": "a + b", "e": "b + c"}),
         {"a": "x", "c": "y", "e": "z"},
-        (["x", "b", "y"], ["d = x + b", "z = b + y"]),
+        (["x", "b", "y"], {"d": "x + b", "z": "b + y"}),
     ),
 ]
 
 
 @pytest.mark.parametrize("function, variable_map, expected_function", RENAME_VARIABLES_TEST_CASES)
 def test_rename_variables(function, variable_map, expected_function, backend):
-    function = SymbolicFunction.from_str(*function, backend)
-    expected_function = SymbolicFunction.from_str(*expected_function, backend)
+    function = SymbolicFunction.assemble(*function, backend)
+    expected_function = SymbolicFunction.assemble(*expected_function, backend)
 
     assert rename_variables(function, variable_map) == expected_function
 
@@ -378,43 +375,43 @@ def test_rename_variables(function, variable_map, expected_function, backend):
 RENAME_INPUTS_AND_OUTPUTS_TEST_CASES = [
     # Ensure non-duplication of inputs
     (
-        (["a", "b"], []),
+        (["a", "b"], {}),
         {"a": "b"},
-        (["b"], []),
+        (["b"], {}),
     ),
     # Ensure non-duplication of outputs
     (
-        ([], ["x = 1", "y = 1"]),
+        ([], {"x": "1", "y": "1"}),
         {"x": "y"},
-        ([], ["y = 1"]),
+        ([], {"y": "1"}),
     ),
     # Ensure simultaneous non-duplication of outputs
     (
-        (["a", "b"], ["x = a", "y = b"]),
+        (["a", "b"], {"x": "a", "y": "b"}),
         {"a": "b", "x": "y"},
-        (["b"], ["y = b"]),
+        (["b"], {"y": "b"}),
     ),
     # Renaming inputs and outputs
     (
-        (["a", "b", "c"], ["d = a + b", "e = b + c"]),
+        (["a", "b", "c"], {"d": "a + b", "e": "b + c"}),
         {"a": "x", "c": "x", "e": "z"},
-        (["x", "b"], ["d = b + x", "z = b + x"]),
+        (["x", "b"], {"d": "b + x", "z": "b + x"}),
     ),
     # Renaming with cycle
     (
-        (["a", "b", "c"], ["d = a + b", "e = b + c"]),
+        (["a", "b", "c"], {"d": "a + b", "e": "b + c"}),
         {"a": "x", "c": "x", "x": "z", "z": "a"},
-        (["a", "b"], ["d = a + b", "e = a + b"]),
+        (["a", "b"], {"d": "a + b", "e": "a + b"}),
     ),
 ]
 
 
 @pytest.mark.parametrize("function, variable_map, expected_results", RENAME_INPUTS_AND_OUTPUTS_TEST_CASES)
 def test_rename_inputs_and_outputs(function, variable_map, expected_results, backend):
-    function = SymbolicFunction.from_str(*function, backend)
+    function = SymbolicFunction.assemble(*function, backend)
     new_inputs, new_outputs = _get_renamed_inputs_and_outputs(function, variable_map)
-    serialized_inputs = _serialize_variables(new_inputs)
-    serialized_outputs = _serialize_variables(new_outputs)
+    serialized_inputs = [var.symbol for var in new_inputs.values()]
+    serialized_outputs = {var.symbol: str(var.expression) for var in new_outputs.values()}
 
     expected_inputs, expected_outputs = expected_results
     assert serialized_inputs == expected_inputs
@@ -423,13 +420,13 @@ def test_rename_inputs_and_outputs(function, variable_map, expected_results, bac
 
 RENAME_INPUTS_AND_OUTPUTS_ERRORS_TEST_CASES: list[tuple[tuple, dict, str]] = [
     # Output renaming would cause a conflict
-    (([], ["x = 1", "y = 2"]), {"x": "y"}, "Cannot rename output variable"),
+    (([], {"x": "1", "y": "2"}), {"x": "y"}, "Cannot rename output variable"),
 ]
 
 
 @pytest.mark.parametrize("function, variable_map, expected_error", RENAME_INPUTS_AND_OUTPUTS_ERRORS_TEST_CASES)
 def test_rename_inputs_and_outputs_errors(function, variable_map, expected_error, backend):
-    function = SymbolicFunction.from_str(*function, backend)
+    function = SymbolicFunction.assemble(*function, backend)
 
     with pytest.raises(BartiqCompilationError, match=re.escape(expected_error)):
         _get_renamed_inputs_and_outputs(function, variable_map)

--- a/tests/compilation/test_symbolic_function.py
+++ b/tests/compilation/test_symbolic_function.py
@@ -51,29 +51,29 @@ def _dummy_resources(cost_strs):
 
 TO_SYMBOLIC_FUNCTION_TEST_CASES = [
     # Null case
-    (_make_routine(), ([], [])),
+    (_make_routine(), ([], {})),
     # Simple case with no register sizes
     (
         _make_routine(input_params=["a", "b"], resources=_dummy_resources(["x = a + b", "y = a - b"])),
-        (["a", "b"], ["x = a + b", "y = a - b"]),
+        (["a", "b"], {"x": "a + b", "y": "a - b"}),
     ),
     # No register sizes, but including local parameters
     (
         _make_routine(
             input_params=["a", "b"],
-            local_variables=["m = a + b", "n = a - b"],
+            local_variables={"m": "a + b", "n": "a - b"},
             resources=_dummy_resources(["x = m + n", "y = m - n"]),
         ),
-        (["a", "b"], ["x = 2 * a", "y = 2 * b"]),
+        (["a", "b"], {"x": "2 * a", "y": "2 * b"}),
     ),
     # No register sizes, but including self-referential local parameters
     (
         _make_routine(
             input_params=["a", "b"],
-            local_variables=["m = a ** 2", "n = b ** 2", "w = m + n"],
+            local_variables={"m": "a ** 2", "n": "b ** 2", "w": "m + n"},
             resources=_dummy_resources(["x = w - m", "y = w - n"]),
         ),
-        (["a", "b"], ["x = b ** 2", "y = a ** 2"]),
+        (["a", "b"], {"x": "b ** 2", "y": "a ** 2"}),
     ),
     # Input and output register sizes
     (
@@ -83,18 +83,18 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
                 **_ports_from_reg_sizes({"psi": "3 * N"}, "out"),
             }
         ),
-        (["#in_psi.N"], ["#out_psi = 3 * #in_psi.N"]),
+        (["#in_psi.N"], {"#out_psi": "3 * #in_psi.N"}),
     ),
     # Input and output register sizes with local parameters
     (
         _make_routine(
-            local_variables=["M = 3 * N"],
+            local_variables={"M": "3 * N"},
             ports={
                 **_ports_from_reg_sizes({"psi": "N"}, "in"),
                 **_ports_from_reg_sizes({"psi": "M"}, "out"),
             },
         ),
-        (["#in_psi.N"], ["#out_psi = 3 * #in_psi.N"]),
+        (["#in_psi.N"], {"#out_psi": "3 * #in_psi.N"}),
     ),
     # Both inputs have the same size
     (
@@ -104,7 +104,7 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
                 **_ports_from_reg_sizes({"0": "2*N"}, "out"),
             }
         ),
-        (["#in_0.N", "#in_1.N"], ["#out_0 = 2*#in_0.N"]),
+        (["#in_0.N", "#in_1.N"], {"#out_0": "2*#in_0.N"}),
     ),
     # Multiple inputs have the same size
     (
@@ -116,7 +116,7 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
         ),
         (
             ["#in_0.A", "#in_1.A", "#in_2.B", "#in_3.C", "#in_4.B", "#in_5.A", "#in_6.C"],
-            ["#out_0 = #in_0.A + #in_2.B + 2*#in_3.C"],
+            {"#out_0": "#in_0.A + #in_2.B + 2*#in_3.C"},
         ),
     ),
     # Multiple inputs have the same size and we use input params
@@ -128,26 +128,26 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
                 **_ports_from_reg_sizes({"0": "2*N"}, "out"),
             },
         ),
-        (["#in_0.N", "#in_1.N", "a", "b"], ["#out_0 = 2*#in_0.N"]),
+        (["#in_0.N", "#in_1.N", "a", "b"], {"#out_0": "2*#in_0.N"}),
     ),
     # Only inputs are subresources
     (
         _make_routine(resources=_dummy_resources(["x = a.N + a.b.N"])),
-        (["a.N", "a.b.N"], ["x = a.N + a.b.N"]),
+        (["a.N", "a.b.N"], {"x": "a.N + a.b.N"}),
     ),
     # Input params and subresources
     (
         _make_routine(input_params=["N"], resources=_dummy_resources(["x = N + a.N + a.b.N"])),
-        (["N", "a.N", "a.b.N"], ["x = N + a.N + a.b.N"]),
+        (["N", "a.N", "a.b.N"], {"x": "N + a.N + a.b.N"}),
     ),
     # Input params, subresources, and local parameters
     (
         _make_routine(
             input_params=["N"],
-            local_variables=["M = N + a.N + a.b.N"],
+            local_variables={"M": "N + a.N + a.b.N"},
             resources=_dummy_resources(["x = M"]),
         ),
-        (["N", "a.N", "a.b.N"], ["x = N + a.N + a.b.N"]),
+        (["N", "a.N", "a.b.N"], {"x": "N + a.N + a.b.N"}),
     ),
     # The whole shebang
     (
@@ -171,10 +171,10 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
                     "out",
                 ),
             },
-            local_variables=[
-                "M = N + a.N + a.b.N",
-                "C = a + b",
-            ],
+            local_variables={
+                "M": "N + a.N + a.b.N",
+                "C": "a + b",
+            },
             resources=_dummy_resources(["x = M + C"]),
             children={
                 "a": {
@@ -186,11 +186,11 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
         ),
         (
             ["N", "a.N", "a.b.N", "#in_psi.a", "#in_phi.b"],
-            [
-                "x = N + a.N + a.b.N + #in_psi.a + #in_phi.b",
-                "#out_psi = N + a.N + a.b.N",
-                "#out_phi = #in_psi.a + #in_phi.b",
-            ],
+            {
+                "x": "N + a.N + a.b.N + #in_psi.a + #in_phi.b",
+                "#out_psi": "N + a.N + a.b.N",
+                "#out_phi": "#in_psi.a + #in_phi.b",
+            },
         ),
     ),
     # Allow reuse of cost in subsequent costs expressions
@@ -206,7 +206,7 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
                     "out",
                 ),
             },
-            local_variables=["b_anc = 1"],
+            local_variables={"b_anc": "1"},
             resources=_dummy_resources(
                 [
                     "Q_anc = b_0",
@@ -217,13 +217,13 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
         ),
         (
             ["#in_comp_0.b_0"],
-            [
-                "Q_anc = #in_comp_0.b_0",
-                "B_anc = 1",
-                "Q = 2*#in_comp_0.b_0 + 1",
-                "#out_comp_0 = #in_comp_0.b_0",
-                "#out_anc = 1",
-            ],
+            {
+                "Q_anc": "#in_comp_0.b_0",
+                "B_anc": "1",
+                "Q": "2*#in_comp_0.b_0 + 1",
+                "#out_comp_0": "#in_comp_0.b_0",
+                "#out_anc": "1",
+            },
         ),
     ),
     # Special case for when an input port has a constant size
@@ -237,14 +237,14 @@ TO_SYMBOLIC_FUNCTION_TEST_CASES = [
                 "in",
             ),
         ),
-        (["#in_foo.bar"], ["#in_0 = 1"]),
+        (["#in_foo.bar"], {"#in_0": "1"}),
     ),
 ]
 
 
 @pytest.mark.parametrize("routine, expected_function", TO_SYMBOLIC_FUNCTION_TEST_CASES)
 def test_to_symbolic_function(routine, expected_function, backend):
-    expected_function = SymbolicFunction.from_str(*expected_function, backend)
+    expected_function = SymbolicFunction.assemble(*expected_function, backend)
 
     assert to_symbolic_function(routine, backend) == expected_function
 
@@ -265,7 +265,7 @@ def test_to_symbolic_function(routine, expected_function, backend):
         # Redundant variable in both costs and local_params
         (
             _make_routine(
-                local_variables=["x = 1"],
+                local_variables={"x": "1"},
                 resources=_dummy_resources(["z = x + 1", "x = 1"]),
             ),
             "Variable is redundantly defined in local_params and costs.",
@@ -288,13 +288,13 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
     # Null case
     (
         _make_routine(),
-        ([], []),
+        ([], {}),
         _make_routine(),
     ),
     # Input-only case
     (
         _make_routine(),
-        (["x", "y"], []),
+        (["x", "y"], {}),
         _make_routine(
             input_params=["x", "y"],
         ),
@@ -305,7 +305,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
             input_params=["x", "y"],
             ports=_ports_from_reg_sizes({"0": None}, "in"),
         ),
-        (["x", "y", "#in_0.z"], []),
+        (["x", "y", "#in_0.z"], {}),
         _make_routine(
             input_params=["x", "y"],
             ports=_ports_from_reg_sizes({"0": "z"}, "in"),
@@ -314,7 +314,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
     # Output-only case
     (
         _make_routine(),
-        ([], ["a = 42", "b = 24"]),
+        ([], {"a": "42", "b": "24"}),
         _make_routine(
             resources=_dummy_resources(["a = 42", "b = 24"]),
         ),
@@ -324,7 +324,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
         _make_routine(
             ports=_ports_from_reg_sizes({"0": None}, "out"),
         ),
-        ([], ["a = 42", "b = 24", "#out_0 = 101"]),
+        ([], {"a": "42", "b": "24", "#out_0": "101"}),
         _make_routine(
             ports=_ports_from_reg_sizes({"0": "101"}, "out"),
             resources=_dummy_resources(["a = 42", "b = 24"]),
@@ -333,7 +333,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
     # Input and output case
     (
         _make_routine(),
-        (["x", "y"], ["a = x + y", "b = x - y"]),
+        (["x", "y"], {"a": "x + y", "b": "x - y"}),
         _make_routine(
             input_params=["x", "y"],
             resources=_dummy_resources(["a = x + y", "b = x - y"]),
@@ -348,7 +348,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
                 **_ports_from_reg_sizes({"0": None}, "out"),
             },
         ),
-        (["x", "y", "#in_0.z"], ["a = x + y", "b = x - y - #in_0.z", "#out_0 = x * y * #in_0.z"]),
+        (["x", "y", "#in_0.z"], {"a": "x + y", "b": "x - y - #in_0.z", "#out_0": "x * y * #in_0.z"}),
         _make_routine(
             input_params=["x", "y"],
             ports={
@@ -369,7 +369,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
                 "in",
             ),
         ),
-        (["#in_foo.bar"], ["#in_0 = 1"]),
+        (["#in_foo.bar"], {"#in_0": "1"}),
         _make_routine(
             ports=_ports_from_reg_sizes(
                 {
@@ -385,7 +385,7 @@ UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES = [
 
 @pytest.mark.parametrize("routine, function, expected_routine", UPDATE_ROUTINE_WITH_SYMBOLIC_FUNCTION_TEST_CASES)
 def test_update_routine_with_symbolic_function(routine, function, expected_routine, backend):
-    function = SymbolicFunction.from_str(*function, backend)
+    function = SymbolicFunction.assemble(*function, backend)
 
     update_routine_with_symbolic_function(routine, function)
     assert routine == expected_routine
@@ -402,12 +402,12 @@ def test_update_routine_with_symbolic_function(routine, function, expected_routi
             _make_routine(
                 ports=_ports_from_reg_sizes({"0": None}, "in"),
             ),
-            (["x"], ["#in_0 = x"]),
+            (["x"], {"#in_0": "x"}),
             "Only constant-sized input register sizes supported in function outputs",
         ),
     ],
 )
 def test_update_routine_with_symbolic_function_fails(routine, function, expected_error, backend):
-    function = SymbolicFunction.from_str(*function, backend)
+    function = SymbolicFunction.assemble(*function, backend)
     with pytest.raises(BartiqCompilationError, match=expected_error):
         update_routine_with_symbolic_function(routine, function)

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -93,10 +93,10 @@ LATEX_TEST_CASES = [
         Routine(
             name="root",
             input_params=["a", "b"],
-            local_variables=[
-                "x_foo = y + a",
-                "y_bar = b * c",
-            ],
+            local_variables={
+                "x_foo": "y + a",
+                "y_bar": "b * c",
+            },
         ),
         {},
         r"""
@@ -163,10 +163,10 @@ LATEX_TEST_CASES = [
                 "d": {"name": "d", "input_params": ["k_2"]},
                 "e": {"name": "e", "input_params": ["l_3"]},
             },
-            local_variables=[
-                "x_foo = a.i_0 + a",
-                "y_bar = b * c.j_1",
-            ],
+            local_variables={
+                "x_foo": "a.i_0 + a",
+                "y_bar": "b * c.j_1",
+            },
             resources={
                 "t": {"name": "t", "value": 0, "type": "additive"},
             },
@@ -196,10 +196,10 @@ LATEX_TEST_CASES = [
     (
         Routine(
             name="root",
-            local_variables=[
-                "a=1+2",
-                "b = 3+4",
-            ],
+            local_variables={
+                "a": "1+2",
+                "b": "3+4",
+            },
             resources={
                 "c": {"name": "c", "value": "a + b", "type": "additive"},
                 "d": {"name": "d", "value": "a-b", "type": "additive"},

--- a/tests/integrations/test_qref_integration.py
+++ b/tests/integrations/test_qref_integration.py
@@ -45,9 +45,7 @@ def example_routine():
                 "name": "foo",
                 "type": None,
                 "input_params": ["M"],
-                "local_variables": [
-                    "R=ceiling(log_2(M))",
-                ],
+                "local_variables": {"R": "ceiling(log_2(M))"},
                 "resources": {"T_gates": {"name": "T_gates", "type": "additive", "value": "R ** 2"}},
                 "ports": {
                     "in_0": {"name": "in_0", "size": "M", "direction": "input"},
@@ -97,9 +95,7 @@ def example_serialized_qref_v1_object():
                         {"name": "out_0", "direction": "output", "size": 3},
                     ],
                     "input_params": ["M"],
-                    "local_variables": [
-                        "R=ceiling(log_2(M))",
-                    ],
+                    "local_variables": {"R": "ceiling(log_2(M))"},
                     "resources": [{"name": "T_gates", "type": "additive", "value": "R ** 2"}],
                 },
             ],

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -60,7 +60,7 @@ def test_verify_uncompiled_routine(routine):
                 name="root",
                 input_params=["N"],
                 resources={"X": {"name": "X", "value": "a +", "type": "other"}},
-                local_variables=["X=a*"],
+                local_variables={"X": "a*"},
                 ports={"in_0": {"name": "in_0", "direction": "input", "size": "#"}},
                 type=None,
             ),


### PR DESCRIPTION
## Description

Currently, we store local variables as a list of strings, each of them of the form "symbol = expression", e.g.:
```python
local_variables = ["a = x + y", "b = 42"]
```
However, each time such variables are processed, this lists of strings gets converted to a dictionary. Therefore, it is only natural to make `local_variables` a dictionary in the first place, so that the example above looks like:

```python
local_variables = {"a": "x+y", "b": "42"}
```
which is what this PR does.

While refactoring this, some functions became obsolete and were thus removed from the codebase entirely as a part of this PR.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.