### PR TITLE
Fixed the bug not passing local_variables from qref to bartiq.

### DIFF
--- a/src/bartiq/integrations/qref.py
+++ b/src/bartiq/integrations/qref.py
@@ -91,6 +91,7 @@ def _routine_v1_to_bartiq_routine(routine_v1) -> Routine:
         type=routine_v1.type,
         ports={port.name: port.model_dump() for port in routine_v1.ports},
         resources={resource.name: resource.model_dump() for resource in routine_v1.resources},
+        local_variables=routine_v1.local_variables,
         connections=[connection.model_dump() for connection in routine_v1.connections],
         input_params=routine_v1.input_params,
         linked_params={

--- a/tests/integrations/test_qref_integration.py
+++ b/tests/integrations/test_qref_integration.py
@@ -33,6 +33,13 @@ def example_routine():
             "out_0": {"name": "out_0", "size": "N", "direction": "output"},
             "out_1": {"name": "out_1", "size": 3, "direction": "output"},
         },
+        resources={
+            "n_qubits": {
+                "name": "n_qubits",
+                "type": "additive",
+                "value": {"value": 30, "type": "int"},
+            },
+        },
         children={
             "foo": {
                 "name": "foo",
@@ -58,13 +65,6 @@ def example_routine():
             },
         },
         linked_params={"N": [("foo", "M"), ("bar", "N")]},
-        resources={
-            "n_qubits": {
-                "name": "n_qubits",
-                "type": "additive",
-                "value": {"value": 30, "type": "int"},
-            },
-        },
         connections=[
             {"source": "in_0", "target": "foo.in_0"},
             {"source": "foo.out_0", "target": "out_0"},

--- a/tests/integrations/test_qref_integration.py
+++ b/tests/integrations/test_qref_integration.py
@@ -38,7 +38,7 @@ def example_routine():
                 "name": "n_qubits",
                 "type": "additive",
                 "value": {"value": 30, "type": "int"},
-            },
+            }
         },
         children={
             "foo": {

--- a/tests/integrations/test_qref_integration.py
+++ b/tests/integrations/test_qref_integration.py
@@ -33,18 +33,15 @@ def example_routine():
             "out_0": {"name": "out_0", "size": "N", "direction": "output"},
             "out_1": {"name": "out_1", "size": 3, "direction": "output"},
         },
-        resources={
-            "n_qubits": {
-                "name": "n_qubits",
-                "type": "additive",
-                "value": {"value": 30, "type": "int"},
-            }
-        },
         children={
             "foo": {
                 "name": "foo",
                 "type": None,
                 "input_params": ["M"],
+                "local_variables": [
+                    "R=ceiling(log_2(M))",
+                ],
+                "resources": {"T_gates": {"name": "T_gates", "type": "additive", "value": "R ** 2"}},
                 "ports": {
                     "in_0": {"name": "in_0", "size": "M", "direction": "input"},
                     "out_0": {"name": "out_0", "size": 3, "direction": "output"},
@@ -61,6 +58,13 @@ def example_routine():
             },
         },
         linked_params={"N": [("foo", "M"), ("bar", "N")]},
+        resources={
+            "n_qubits": {
+                "name": "n_qubits",
+                "type": "additive",
+                "value": {"value": 30, "type": "int"},
+            },
+        },
         connections=[
             {"source": "in_0", "target": "foo.in_0"},
             {"source": "foo.out_0", "target": "out_0"},
@@ -93,6 +97,10 @@ def example_serialized_qref_v1_object():
                         {"name": "out_0", "direction": "output", "size": 3},
                     ],
                     "input_params": ["M"],
+                    "local_variables": [
+                        "R=ceiling(log_2(M))",
+                    ],
+                    "resources": [{"name": "T_gates", "type": "additive", "value": "R ** 2"}],
                 },
             ],
             "type": None,


### PR DESCRIPTION
## Description

- Context: This pull request resolves issue #81 to ensure that local variables are correctly passed when converting qref to the bartiq routines.

- Concise description of the implemented solution: This PR modifies the _routine_v1_to_bartiq_routine function to ensure that local variables are correctly passed and included in the resulting routine. 

- Dependencies: No new dependencies are added.
## Please verify that you have completed the following steps
- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.