### PR TITLE
fix: Fix port direction handling in Qref export

### DIFF
--- a/src/bartiq/integrations/qref.py
+++ b/src/bartiq/integrations/qref.py
@@ -19,6 +19,13 @@ from qref import SchemaV1
 from .. import Port, Routine
 
 
+def _serialize_port_direction(port_direction):
+    try:
+        return port_direction.value
+    except AttributeError:
+        return str(port_direction)
+
+
 def bartiq_to_qref(routine: Routine, version: str = "v1") -> SchemaV1:
     """Convert Bartiq routine to QREF object."""
     if version != "v1":
@@ -58,7 +65,7 @@ def _bartiq_routine_to_qref_v1_dict(routine: Routine) -> dict:
         "ports": [
             {
                 "name": port.name,
-                "direction": str(port.direction),
+                "direction": _serialize_port_direction(port.direction),
                 "size": _ensure_primitive_type(port.size),
             }
             for port in routine.ports.values()

--- a/tests/integrations/test_qref_integration.py
+++ b/tests/integrations/test_qref_integration.py
@@ -15,7 +15,7 @@
 import pytest
 from pytest import fixture
 
-from bartiq import Routine
+from bartiq import Port, Routine
 from bartiq.integrations import bartiq_to_qref, qref_to_bartiq
 
 # Note: fixture example_routine has to be synced with
@@ -128,3 +128,16 @@ def test_converting_qref_v1_object_to_routine_give_correct_output(example_routin
 def test_conversion_from_bartiq_to_qref_raises_an_error_if_version_is_unsupported(example_routine):
     with pytest.raises(ValueError):
         bartiq_to_qref(example_routine, version="v3")
+
+
+def test_routine_with_explicitly_constructed_port_successfully_converts_into_qref():
+    routine = Routine(
+        name="root", ports={"in_0": Port.model_validate({"name": "in_0", "direction": "input", "size": 1})}
+    )
+
+    expected_qref_dict = {
+        "version": "v1",
+        "program": {"name": "root", "type": None, "ports": [{"name": "in_0", "size": 1, "direction": "input"}]},
+    }
+
+    assert bartiq_to_qref(routine).model_dump(exclude_unset=True) == expected_qref_dict


### PR DESCRIPTION
## Description

Consider the following two routines, which might seem identical at first glance:
```python
routine1 = Routine(name="root", ports={"in": {"name": "in", "direction": "input", "size": 1}})
routine2 = Routine(name="root", ports={"in": Port.model_validate({"name": "in", "direction": "input", "size": 1})})
```
The reason why those two should be identical is that the dictionary for the input port in `routine1` has to be converted to `Port` anyway. In both cases `routine.ports["in"].direction` should be the same, and equal to string "input", because we have our models configured with [`use_enum_values`](https://docs.pydantic.dev/2.0/api/config/#pydantic.config.ConfigDict). However, for whatever reason, in the second case the actual direction is a member of `PortDirection` enum. This is not a problem for Bartiq, but it is a problem for Qref, which is why we have to deal with such misbehaving ports when converting from Bartiq's `Routine` to Qref's `SchemaV1`.

This PR introduces correct handling of port directions and adds a test case that fails without the proposed changes. The documentation is not updated, as the changes are not user-facing.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.