### PR TITLE
feat: Properly implement multiplicity as Sympy custom function

### DIFF
--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -29,7 +29,7 @@ from typing_extensions import TypeAlias
 from ..compilation.types import Number
 from ..errors import BartiqCompilationError
 from .ast_parser import parse
-from .sympy_interpreter import SPECIAL_FUNCS, TRY_IF_POSSIBLE_FUNCS, SympyInterpreter
+from .sympy_interpreter import SPECIAL_FUNCS, SympyInterpreter
 from .sympy_interpreter import parse_to_sympy as legacy_parse_to_sympy
 from .sympy_serializer import serialize_expression
 
@@ -37,7 +37,7 @@ NUM_DIGITS_PRECISION = 15
 # Order included here to allow for user-defined big O's
 SYMPY_USER_FUNCTION_TYPES = (AppliedUndef, Order)
 
-BUILT_IN_FUNCTIONS = list(SPECIAL_FUNCS) + list(TRY_IF_POSSIBLE_FUNCS)
+BUILT_IN_FUNCTIONS = list(SPECIAL_FUNCS)
 
 
 T_expr: TypeAlias = Expr
@@ -125,11 +125,7 @@ class SympyBackend:
 
     def substitute(self, expr: T_expr, symbol: str, replacement: Union[T_expr, Number]) -> T_expr:
         """Substitute occurrences of given symbol with an expression or numerical value."""
-        return (
-            self.as_expression(self.serialize(expr.subs(symbols(symbol), replacement)))
-            if symbol in self.free_symbols_in(expr)
-            else expr
-        )
+        return expr.subs(symbols(symbol), replacement) if symbol in self.free_symbols_in(expr) else expr
 
     def rename_function(self, expr: T_expr, old_name: str, new_name: str) -> T_expr:
         """Rename all instances of given function call."""

--- a/tests/symbolics/test_sympy_interpreter.py
+++ b/tests/symbolics/test_sympy_interpreter.py
@@ -50,7 +50,6 @@ from sympy import (
     frac,
     im,
     log,
-    multiplicity,
     prod,
     re,
     sec,
@@ -65,7 +64,7 @@ from sympy.codegen.cfunctions import exp2, log2, log10
 from sympy.core.numbers import S as sympy_constants
 
 from bartiq.symbolics.sympy_backends import parse_to_sympy
-from bartiq.symbolics.sympy_interpreter import SPECIAL_PARAMS, Round
+from bartiq.symbolics.sympy_interpreter import SPECIAL_PARAMS, Round, multiplicity
 from bartiq.symbolics.sympy_interpreter import parse_to_sympy as legacy_parse_to_sympy
 from bartiq.symbolics.sympy_serializer import serialize_expression
 
@@ -365,9 +364,9 @@ PARSE_TEST_CASES = [
     ("x / y // z", (x / y) // z),
     ("x ^ y ** z", x ** (y**z)),
     # Special functions
-    ("multiplicity(x, y)", Function("multiplicity")(x, y)),
-    ("multiplicity(x, 2)", Function("multiplicity")(x, 2)),
-    ("multiplicity(2, y)", Function("multiplicity")(2, y)),
+    ("multiplicity(x, y)", multiplicity(x, y)),
+    ("multiplicity(x, 2)", multiplicity(x, 2)),
+    ("multiplicity(2, y)", multiplicity(2, y)),
     ("multiplicity(2, 40)", multiplicity(2, 40)),
     # Expressions with wildcard
     ("sum(~.X)", Function("sum")(Symbol("~.X"))),


### PR DESCRIPTION
## Description

Currently, we use very peculiar logic for handling multiplicity. If `multiplicity` is given symbolic parameters, it is not possible to substitute them with numbers and obtain a concrete value (instead of `multiplicity(p, n)` symbol). This is because if initial evaluation of multiplicity fails, a dummy `Function("multiplicity")` is placed in the expression, and obviously there is no way for Sympy to know any rules about evaluating substitution into this object.

This PR implements multiplicity as a proper custom Sympy function. This has two main benefits:
- Simplified logic in `create_function`.
- Roundtrip through `serialize` is no longer needed to trigger multiplicity evaluation, which has obvious performance benefits.

I think this closes https://github.com/PsiQ/bartiq/issues/25

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.