### PR TITLE
fix: make resource aggregation not delete resources

### DIFF
--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -74,7 +74,7 @@ def _add_aggregated_resources_to_subroutine(
                     )
                     aggregated_resources[sub_res] = new_resource
 
-            del aggregated_resources[resource_name]
+            # del aggregated_resources[resource_name]
 
     subroutine.resources = aggregated_resources
     return subroutine
@@ -87,9 +87,6 @@ def _expand_aggregation_dict(aggregation_dict: Dict[str, Dict[str, Any]], backen
     Returns:
         Dict[str, Dict[str, Any]]: The expanded aggregation dictionary.
     """
-    if not isinstance(aggregation_dict, dict):
-        raise TypeError("aggregation_dict must be a dictionary.")
-
     sorted_resources = _topological_sort(aggregation_dict)
 
     expanded_dict = {}

--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -74,8 +74,6 @@ def _add_aggregated_resources_to_subroutine(
                     )
                     aggregated_resources[sub_res] = new_resource
 
-            # del aggregated_resources[resource_name]
-
     subroutine.resources = aggregated_resources
     return subroutine
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -93,7 +93,8 @@ def _generate_test(subroutine, input_params, linked_params):
                         },
                         resources={
                             "CNOT": {"name": "CNOT", "type": "additive", "value": "8*num"},
-                            "T_gates": {"name": "control_ry", "type": "additive", "value": "300*num"},
+                            "T_gates": {"name": "T_gates", "type": "additive", "value": "300*num"},
+                            "control_ry": {"name": "control_ry", "type": "additive", "value": "3*num"},
                         },
                         local_variables={"n": "x"},
                     )
@@ -135,6 +136,11 @@ def _generate_test(subroutine, input_params, linked_params):
                                 "name": "T_gates",
                                 "type": "additive",
                                 "value": "ceiling(5*num/2)*(3*log2(1/epsilon) + O(log(log(1/epsilon))))",
+                            },
+                            "arbitrary_z": {
+                                "name": "arbitrary_z",
+                                "type": "additive",
+                                "value": "ceiling(5*num/2)",
                             },
                         },
                         local_variables={"n": "x"},


### PR DESCRIPTION
## Description

I looked once more at `add_aggregated_resources` and I realized that it deletes the "consumed" resource, so I changed it, as I feel it's valuable information that we don't necessarily want to throw away.

@sitong1011 please take a look and let me know if this change makes sense and doesn't accidentally breaks something 😅 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.