### PR TITLE
Added input params to basic_example.json

### DIFF
--- a/docs/data/basic_example.json
+++ b/docs/data/basic_example.json
@@ -83,6 +83,9 @@
                 "target": "out"
             }
         ],
+        "input_params" : [
+            "N"
+        ],
         "linked_params": [
             {
                 "source": "N",


### PR DESCRIPTION
## Description
Fixes #104 

This PR adds input_params to basic_example.json since it fails with the routine verification.

bartiq.errors.BartiqCompilationError: Found the following issues with the provided routine before the compilation started: ['N is present in linked_params, but not in input_params.\n']

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.