### PR TITLE
fix: Add parameter to decide wheter remove resource in aggregation function 

### DIFF
--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -83,7 +83,6 @@ def _add_aggregated_resources_to_subroutine(
             if remove_decomposed:
                 del aggregated_resources[resource_name]
             else:
-                # type_str = "_".join([f"decomposed_to_{target}" for target in sub_res])
                 aggregated_resources[resource_name].type = "other"
 
     subroutine.resources = aggregated_resources
@@ -97,8 +96,6 @@ def _expand_aggregation_dict(aggregation_dict: Dict[str, Dict[str, Any]], backen
     Returns:
         Dict[str, Dict[str, Any]]: The expanded aggregation dictionary.
     """
-    if not isinstance(aggregation_dict, dict):
-        raise TypeError("aggregation_dict must be a dictionary.")
 
     sorted_resources = _topological_sort(aggregation_dict)
 

--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -17,7 +17,7 @@ import copy
 from collections import defaultdict
 from typing import Any, Dict, List, Set
 
-from bartiq import Resource, Routine, ResourceType
+from bartiq import Resource, ResourceType, Routine
 from bartiq.symbolics import sympy_backend
 from bartiq.verification import verify_uncompiled_routine
 
@@ -84,7 +84,6 @@ def _add_aggregated_resources_to_subroutine(
                 del aggregated_resources[resource_name]
             else:
                 aggregated_resources[resource_name].type = ResourceType.other
-
 
     subroutine.resources = aggregated_resources
     return subroutine

--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -24,7 +24,9 @@ from bartiq.verification import verify_uncompiled_routine
 BACKEND = sympy_backend
 
 
-def add_aggregated_resources(routine: Routine, aggregation_dict: Dict[str, Dict[str, Any]], backend=BACKEND) -> Routine:
+def add_aggregated_resources(
+    routine: Routine, aggregation_dict: Dict[str, Dict[str, Any]], remove_decomposed: bool = True, backend=BACKEND
+) -> Routine:
     """Add aggregated resources to bartiq routine based on the aggregation dictionary.
 
     Args:
@@ -37,6 +39,10 @@ def add_aggregated_resources(routine: Routine, aggregation_dict: Dict[str, Dict[
                               "arbitrary_z": {"T_gates": "3*log2(1/epsilon) + O(log(log(1/epsilon)))"},
                               ...
                           }
+        remove_decomposed : Whether to remove the decomposed resources from the routine.
+            Defaults to True.
+        backend : Backend instance to use for handling expressions.
+            Defaults to `sympy_backend`.
 
     Returns:
         Routine: The program with aggregated resources.
@@ -46,13 +52,14 @@ def add_aggregated_resources(routine: Routine, aggregation_dict: Dict[str, Dict[
 
     expanded_aggregation_dict = _expand_aggregation_dict(aggregation_dict)
     for subroutine in routine.walk():
-        _add_aggregated_resources_to_subroutine(subroutine, expanded_aggregation_dict)
+        _add_aggregated_resources_to_subroutine(subroutine, expanded_aggregation_dict, remove_decomposed, backend)
     return routine
 
 
 def _add_aggregated_resources_to_subroutine(
-    subroutine: Routine, expanded_aggregation_dict: Dict[str, Dict[str, Any]], backend=BACKEND
+    subroutine: Routine, expanded_aggregation_dict: Dict[str, Dict[str, Any]], remove_decomposed: bool, backend=BACKEND
 ) -> Routine:
+
     if not hasattr(subroutine, "resources") or not subroutine.resources:
         return subroutine
 
@@ -73,8 +80,11 @@ def _add_aggregated_resources_to_subroutine(
                         value=str(multiplier_expr * resource_expr),
                     )
                     aggregated_resources[sub_res] = new_resource
-
-            del aggregated_resources[resource_name]
+            if remove_decomposed:
+                del aggregated_resources[resource_name]
+            else:
+                # type_str = "_".join([f"decomposed_to_{target}" for target in sub_res])
+                aggregated_resources[resource_name].type = "other"
 
     subroutine.resources = aggregated_resources
     return subroutine

--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -17,7 +17,7 @@ import copy
 from collections import defaultdict
 from typing import Any, Dict, List, Set
 
-from bartiq import Resource, Routine
+from bartiq import Resource, Routine, ResourceType
 from bartiq.symbolics import sympy_backend
 from bartiq.verification import verify_uncompiled_routine
 
@@ -83,7 +83,8 @@ def _add_aggregated_resources_to_subroutine(
             if remove_decomposed:
                 del aggregated_resources[resource_name]
             else:
-                aggregated_resources[resource_name].type = "other"
+                aggregated_resources[resource_name].type = ResourceType.other
+
 
     subroutine.resources = aggregated_resources
     return subroutine

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -14,6 +14,7 @@
 
 import pytest
 import sympy
+
 from bartiq import Routine
 from bartiq.integrations import qref_to_bartiq
 from bartiq.transform import add_aggregated_resources

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -14,7 +14,6 @@
 
 import pytest
 import sympy
-
 from bartiq import Routine
 from bartiq.integrations import qref_to_bartiq
 from bartiq.transform import add_aggregated_resources
@@ -70,7 +69,7 @@ def _generate_test(subroutine, input_params, linked_params):
 
 
 @pytest.mark.parametrize(
-    "aggregation_dict, generate_test_fn, expected_output",
+    "aggregation_dict, generate_test_fn, remove_decomposed, expected_output",
     [
         (
             {"control_ry": {"rotation": 2, "CNOT": 2}, "rotation": {"T_gates": 50}},
@@ -79,6 +78,7 @@ def _generate_test(subroutine, input_params, linked_params):
                 ["z", "num"],
                 [{"source": "z", "targets": ["ccry_gate.x"]}, {"source": "num", "targets": ["ccry_gate.num"]}],
             ),
+            True,
             Routine(
                 name="test_qref",
                 input_params=["z", "num"],
@@ -118,6 +118,7 @@ def _generate_test(subroutine, input_params, linked_params):
                 ["z", "num"],
                 [{"source": "z", "targets": ["arbitrary_z.x"]}, {"source": "num", "targets": ["arbitrary_z.num"]}],
             ),
+            True,
             Routine(
                 name="test_qref",
                 input_params=["z", "num"],
@@ -152,10 +153,54 @@ def _generate_test(subroutine, input_params, linked_params):
                 ],
             ),
         ),
+        (
+            {"control_ry": {"rotation": 2, "CNOT": 2}, "rotation": {"T_gates": 50}},
+            _generate_test(
+                ccry_gate,
+                ["z", "num"],
+                [{"source": "z", "targets": ["ccry_gate.x"]}, {"source": "num", "targets": ["ccry_gate.num"]}],
+            ),
+            False,
+            Routine(
+                name="test_qref",
+                input_params=["z", "num"],
+                children={
+                    "ccry_gate": Routine(
+                        name="ccry_gate",
+                        type=None,
+                        input_params=["x", "num"],
+                        ports={
+                            "in": {"name": "in", "direction": "input", "size": "n"},
+                            "out": {"name": "out", "direction": "output", "size": "n"},
+                        },
+                        resources={
+                            "CNOT": {"name": "CNOT", "type": "additive", "value": "8*num"},
+                            "T_gates": {"name": "control_ry", "type": "additive", "value": "300*num"},
+                            "control_ry": {
+                                "name": "control_ry",
+                                "type": "other",
+                                "value": "3*num",
+                            },
+                        },
+                        local_variables={"n": "x"},
+                    )
+                },
+                type=None,
+                linked_params={"z": [("ccry_gate", "x")], "num": [("ccry_gate", "num")]},
+                ports={
+                    "in": {"name": "in", "direction": "input", "size": "z"},
+                    "out": {"name": "out", "direction": "output", "size": "z"},
+                },
+                connections=[
+                    {"source": "in", "target": "ccry_gate.in"},
+                    {"source": "ccry_gate.out", "target": "out"},
+                ],
+            ),
+        ),
     ],
 )
-def test_add_aggregated_resources(aggregation_dict, generate_test_fn, expected_output):
-    result = add_aggregated_resources(generate_test_fn, aggregation_dict)
+def test_add_aggregated_resources(aggregation_dict, generate_test_fn, remove_decomposed, expected_output):
+    result = add_aggregated_resources(generate_test_fn, aggregation_dict, remove_decomposed=remove_decomposed)
     _compare_routines(result, expected_output)
 
 


### PR DESCRIPTION
## **Description**

This PR solves issue #106 by adding the `remove_decomposed` parameter to the `add_aggregated_resources` function.

### **Context**:
In certain use cases, it is necessary to preserve the original resources after they have been aggregated. Previously, the `add_aggregated_resources` function automatically removed the original resources after aggregation.

### **Implemented Solution**:
- A boolean parameter `remove_decomposed` has been added to the `add_aggregated_resources` function.
  - **If `remove_original=True`** (default): The original resource is removed after aggregation.
  - **If `remove_original=False`**: The original resource is retained, and its type is marked as "other" to distinguish it from other resources (a straightforward approach; however, there may be more optimized solutions.)
- Test cases have been added to validate the correct functioning of this new parameter in both scenarios (`True` and `False`).

### **Dependencies**:
No new dependencies were added in this PR.

## **Please verify that you have completed the following steps**

- [x] I have self-reviewed my code.
- [x] I have included test cases validating the introduced feature.
- [x] I have updated documentation.