### PR TITLE
Fix constraint evaluation

### DIFF
--- a/src/bartiq/compilation/__init__.py
+++ b/src/bartiq/compilation/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._compile import CompilationResult, ConstraintValidationError, compile_routine
+from ._compile import CompilationResult, compile_routine
 from ._evaluate import EvaluationResult, evaluate
 
-__all__ = ["compile_routine", "CompilationResult", "ConstraintValidationError", "evaluate", "EvaluationResult"]
+__all__ = ["compile_routine", "CompilationResult", "evaluate", "EvaluationResult"]

--- a/src/bartiq/compilation/_common.py
+++ b/src/bartiq/compilation/_common.py
@@ -11,15 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import replace
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
 from typing import Callable, TypeVar
 
-from .._routine import Port, Resource
-from ..symbolics.backend import SymbolicBackend, TExpr
+from .._routine import Constraint, ConstraintStatus, Port, Resource
+from ..symbolics.backend import ComparisonResult, SymbolicBackend, TExpr
 
 T = TypeVar("T", covariant=True)
 
 FunctionsMap = dict[str, Callable[[TExpr[T]], TExpr[T]]]
+
+
+@dataclass(frozen=True)
+class Context:
+    path: str
+
+    def descend(self, next_path: str) -> Context:
+        return replace(self, path=".".join((self.path, next_path)))
+
+
+class ConstraintValidationError(ValueError):
+    """Raised when a constraint in the compilation process is violated."""
+
+    def __init__(self, original_constraint: Constraint[T], compiled_constraint: Constraint[T]):
+        super().__init__(original_constraint, compiled_constraint)
 
 
 def _evaluate_and_define_functions(
@@ -60,3 +78,38 @@ def evaluate_resources(
         )
         for name, resource in resources.items()
     }
+
+
+def _evaluate_constraint(
+    constraint: Constraint[T], inputs: dict[str, TExpr[T]], backend: SymbolicBackend[T], custom_funcs: FunctionsMap[T]
+) -> Constraint[T]:
+    lhs = _evaluate_and_define_functions(constraint.lhs, inputs, custom_funcs, backend)
+    rhs = _evaluate_and_define_functions(constraint.rhs, inputs, custom_funcs, backend)
+
+    if (comparison_result := backend.compare(lhs, rhs)) == ComparisonResult.equal:
+        status = ConstraintStatus.satisfied
+    elif comparison_result == ComparisonResult.unequal:
+        status = ConstraintStatus.violated
+    else:
+        status = ConstraintStatus.inconclusive
+
+    new_constraint = Constraint(lhs=lhs, rhs=rhs, status=status)
+
+    if new_constraint.status == ConstraintStatus.violated:
+        raise ConstraintValidationError(constraint, new_constraint)
+
+    return new_constraint
+
+
+def evaluate_constraints(
+    constraints: Iterable[Constraint[T]],
+    inputs: dict[str, TExpr[T]],
+    backend: SymbolicBackend[T],
+    custom_funcs: FunctionsMap[T] | None = None,
+) -> Iterable[Constraint[T]]:
+    custom_funcs = {} if custom_funcs is None else custom_funcs
+    return tuple(
+        _evaluate_constraint(constraint, inputs, backend, custom_funcs)
+        for constraint in constraints
+        if constraint.status != ConstraintStatus.satisfied
+    )

--- a/tests/compilation/test_evaluate.py
+++ b/tests/compilation/test_evaluate.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-import sys
 from pathlib import Path
 
 import pytest
@@ -161,8 +160,6 @@ def test_evaluation_raises_error_when_constraint_is_violated(backend):
 
 @pytest.mark.filterwarnings("ignore:Found the following issues")
 def test_compile_and_evaluate_double_factorization_routine(backend):
-    # Compilation fails on Python 3.9 for the default recursion limit, so we increased it to make this test pass.
-    sys.setrecursionlimit(2000)
     with open(Path(__file__).parent / "data/df_qref.yaml") as f:
         routine = SchemaV1(**yaml.safe_load(f))
 


### PR DESCRIPTION
## Description

Currently, the constraints are taken into account only when compiling routine. However, constraint validation can also occur during an evaluation (if constraint turned to be ambiguous during the compilation). This PR implements handling of constraints during evaluation. Similarly to the compilation phase, while evaluating, the trivial constraints are dropped, vilated constraints raise an error, and ambiguous constraints are preserved.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- N/A I have updated documentation.