### PR TITLE
fix: Fix LaTeX rendering in docs

### DIFF
--- a/docs/javascript/config.js
+++ b/docs/javascript/config.js
@@ -1,0 +1,15 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["$", "$"]],
+    displayMath: [["$$", "$$"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+}
+
+document$.subscribe(() => { 
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
+  MathJax.typesetPromise()
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
-
+extra_javascript:
+  - javascript/config.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 extra:
   version:
     provider: mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,8 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
 extra_javascript:
+  # Configuration for MathJax adapted from the official docs:
+  # https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax
   - javascript/config.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 extra:


### PR DESCRIPTION
## Description

Rendering LaTeX formulas in docs didn't work properly (as notice by @mstechly ). This PR fixes it.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- N/A I have included test cases validating introduced feature/fix.
- N/A I have updated documentation.