### PR TITLE
feat: Use ensure_routine to streamline conversion from Qref to Bartiq

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3270,13 +3270,13 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qref"
-version = "0.7.0"
+version = "0.8.0"
 description = "Quantum Resource Estimation Format"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "<4.0,>=3.10"
 files = [
-    {file = "qref-0.7.0-py3-none-any.whl", hash = "sha256:caaf392ff8560e1201489c80824896c6bb52005eda4237272df200f850a31cd9"},
-    {file = "qref-0.7.0.tar.gz", hash = "sha256:e4e70ea45e821b9a73bf5d6e8de8fb48ef315761617132b192cfdc54092329c9"},
+    {file = "qref-0.8.0-py3-none-any.whl", hash = "sha256:fd8a1c67ada0e857b00b73e1c018944fadcaf60dea41cb426b88be2bcded7e67"},
+    {file = "qref-0.8.0.tar.gz", hash = "sha256:9637f640b66e43aefa819f0919b9df3cb2e9b2cd82f2960326f7845899efbedc"},
 ]
 
 [package.dependencies]
@@ -4020,4 +4020,4 @@ optimization = ["scipy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5a0cc50c024712c95b3bacdc9f652c54403cc2995c12624ad905b2876e184747"
+content-hash = "19e66a129cb3d4abec38e33d76fb0008b9622ce8ccb98fb9acc7f5c16a0a888b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.10"
 pydantic = "^2.7"
 sympy = "^1.12"
 pyparsing ="~3.1.2"
-qref = "0.7.0"
+qref = "0.8.0"
 
 # A list of all of the optional dependencies, some of which are included in the
 # below `extras`. They can be opted into by apps.

--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -20,6 +20,7 @@ from graphlib import TopologicalSorter
 from typing import Generic, Literal, TypeVar, cast
 
 from qref import SchemaV1
+from qref.functools import AnyQrefType, ensure_routine
 from qref.schema_v1 import PortV1, ResourceV1, RoutineV1
 from typing_extensions import Self, TypedDict
 
@@ -120,8 +121,8 @@ class Routine(Generic[T]):
         return {port_name: port for port_name, port in self.ports.items() if port.direction in directions}
 
     @classmethod
-    def from_qref(cls, qref_obj: SchemaV1 | RoutineV1, backend: SymbolicBackend[T]) -> Routine[T]:
-        program = qref_obj.program if isinstance(qref_obj, SchemaV1) else qref_obj
+    def from_qref(cls, qref_obj: AnyQrefType, backend: SymbolicBackend[T]) -> Routine[T]:
+        program = ensure_routine(qref_obj)
         return Routine[T](
             children={child.name: cls.from_qref(child, backend) for child in program.children},
             local_variables={var: backend.as_expression(expr) for var, expr in program.local_variables.items()},
@@ -145,18 +146,16 @@ class CompiledRoutine(Generic[T]):
     constraints: Iterable[Constraint[T]] = ()
 
     @classmethod
-    def from_qref(cls, qref_obj: SchemaV1 | RoutineV1, backend: SymbolicBackend[T]) -> CompiledRoutine[T]:
-        program = qref_obj.program if isinstance(qref_obj, SchemaV1) else qref_obj
+    def from_qref(cls, qref_obj: AnyQrefType, backend: SymbolicBackend[T]) -> CompiledRoutine[T]:
+        program = ensure_routine(qref_obj)
         return CompiledRoutine[T](
             children={child.name: cls.from_qref(child, backend) for child in program.children},
             **_common_routine_dict_from_qref(qref_obj, backend),
         )
 
 
-def _common_routine_dict_from_qref(
-    qref_obj: SchemaV1 | RoutineV1, backend: SymbolicBackend[T]
-) -> _CommonRoutineParams[T]:
-    program = qref_obj.program if isinstance(qref_obj, SchemaV1) else qref_obj
+def _common_routine_dict_from_qref(qref_obj: AnyQrefType, backend: SymbolicBackend[T]) -> _CommonRoutineParams[T]:
+    program = ensure_routine(qref_obj)
     return {
         "name": program.name,
         "type": program.type,

--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -122,6 +122,7 @@ class Routine(Generic[T]):
 
     @classmethod
     def from_qref(cls, qref_obj: AnyQrefType, backend: SymbolicBackend[T]) -> Routine[T]:
+        """Load Routine from a QREF definition, using specified backend for parsing expressions."""
         program = ensure_routine(qref_obj)
         return Routine[T](
             children={child.name: cls.from_qref(child, backend) for child in program.children},
@@ -147,6 +148,7 @@ class CompiledRoutine(Generic[T]):
 
     @classmethod
     def from_qref(cls, qref_obj: AnyQrefType, backend: SymbolicBackend[T]) -> CompiledRoutine[T]:
+        """Load CompiledRoutine from a QREF definition, using specified backend for parsing expressions."""
         program = ensure_routine(qref_obj)
         return CompiledRoutine[T](
             children={child.name: cls.from_qref(child, backend) for child in program.children},

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -20,6 +20,7 @@ from graphlib import TopologicalSorter
 from typing import Generic, TypeVar
 
 from qref import SchemaV1
+from qref.functools import ensure_routine
 from qref.schema_v1 import RoutineV1
 from qref.verification import verify_topology
 
@@ -101,10 +102,7 @@ def compile_routine(
             raise BartiqCompilationError(
                 f"Found the following issues with the provided routine before the compilation started: {problems}",
             )
-    if isinstance(routine, Routine):
-        root = routine
-    else:
-        root = Routine[T].from_qref(routine, backend)
+    root = routine if isinstance(routine, Routine) else Routine[T].from_qref(ensure_routine(routine), backend)
 
     for stage in preprocessing_stages:
         root = stage(root, backend)


### PR DESCRIPTION
## Description

This uses the recently introduced `ensure_routine` from `qref.functools` to streamline conversions between Qref objects and Bartiq native dataclasses. Relies on psiq/qref#122 to be merged first (and then Qref to be released).

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.