### PR TITLE
Fix handling of function names with "lambda" in them

### DIFF
--- a/src/bartiq/symbolics/ast_parser.py
+++ b/src/bartiq/symbolics/ast_parser.py
@@ -73,6 +73,7 @@ _IDENTIFIER = r"[_a-zA-Z]\w*"
 _NAMESPACE_IDENTIFIER = rf"{_IDENTIFIER}(\.{_IDENTIFIER})*"
 _PORT_PATTERN = rf"#({_NAMESPACE_IDENTIFIER})"
 _WILDCARD_PATTERN = rf"(({_IDENTIFIER})?)~"
+_LAMBDA_PATTERN = r"(?<![_A-Za-z])lambda(?![A-Za-z])"
 _IN_PATTERN = r"(^|[^\w])in($|[^\w])"
 
 _RESTRICTED_NAMES = {"__lambda__": "lambda", "__in__": "in"}
@@ -133,7 +134,7 @@ def _contains_lambda(expression):
 
 
 def _replace_lambda(expression):
-    return expression.replace("lambda", "__lambda__")
+    return re.sub(_LAMBDA_PATTERN, "__lambda__", expression)
 
 
 # Preprocessing stage replacing symbols named lambda with symbols named __lambda__

--- a/tests/symbolics/test_sympy_interpreter.py
+++ b/tests/symbolics/test_sympy_interpreter.py
@@ -377,6 +377,8 @@ PARSE_TEST_CASES = [
     ("a.in", Symbol("a.in")),
     ("a.in.b", Symbol("a.in.b")),
     ("in.b", Symbol("in.b")),
+    # Lambda as a part of function name
+    ("calc_lambda(x)", Function("calc_lambda")(Symbol("x"))),
 ]
 
 


### PR DESCRIPTION
## Description

Currently Bartiq messes up parsing functions and variables that contain word "lambda" (e.g. `calc_lambda`). This fixes it.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.