### PR TITLE
docs: add advanced tutorial to docs

### DIFF
--- a/docs/tutorials/03_advanced_examples.ipynb
+++ b/docs/tutorials/03_advanced_examples.ipynb
@@ -5,7 +5,7 @@
    "id": "2ca189df-224d-4bea-881d-2996b4c01c8a",
    "metadata": {},
    "source": [
-    "# Using bartiq for Resource Analysis"
+    "# Using Bartiq for Resource Analysis"
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,9 @@ nav:
       - tutorials/index.md
       - tutorials/01_basic_example.ipynb
       - tutorials/02_alias_sampling_basic.ipynb
+      - tutorials/03_advanced_examples.ipynb
   - Concepts:
       - concepts/compilation.md
-      - concepts/precompilation.md
   - troubleshooting.md
   - limitations.md
   - reference.md


### PR DESCRIPTION
## Description

Adds a link to the newest tutorial and removes broken link in the `concepts` section.