### PR TITLE
fix: Fix nontrivial input port size support

### DIFF
--- a/src/bartiq/compilation/preprocessing.py
+++ b/src/bartiq/compilation/preprocessing.py
@@ -138,7 +138,7 @@ def _introduce_port_variables(routine: Routine[T], backend: SymbolicBackend[T]) 
             ]
             if missing_symbols:
                 raise BartiqPrecompilationError(
-                    f"Size of the port {port.name} depends on symbols {missing_symbols} which are undefined."
+                    f"Size of the port {port.name} depends on symbols {sorted(missing_symbols)} which are undefined."
                 )
             new_size = backend.substitute_all(port.size, additional_local_variables)
             new_ports[port.name] = replace(port, size=new_size)


### PR DESCRIPTION
## Description

Fixes #127 by introducing relevant logic for handling non-trivial input port sizes depending on other ports.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.