### PR TITLE
feat: Enable casting to native types and obtaining backend-native functions

### DIFF
--- a/src/bartiq/_routine.py
+++ b/src/bartiq/_routine.py
@@ -187,13 +187,13 @@ def _endpoint_from_qref(endpoint: str) -> Endpoint:
 def _port_to_qref(port: Port[T], backend: SymbolicBackend[T]) -> PortV1:
     return PortV1(
         name=port.name,
-        size=backend.serialize(port.size),
+        size=backend.as_native(port.size),
         direction=cast(Literal["input", "output", "through"], port.direction),
     )
 
 
 def _resource_to_qref(resource: Resource[T], backend: SymbolicBackend[T]) -> ResourceV1:
-    return ResourceV1(name=resource.name, type=resource.type.value, value=backend.serialize(resource.value))
+    return ResourceV1(name=resource.name, type=resource.type.value, value=backend.as_native(resource.value))
 
 
 def _endpoint_to_qref(endpoint: Endpoint) -> str:

--- a/src/bartiq/symbolics/backend.py
+++ b/src/bartiq/symbolics/backend.py
@@ -78,3 +78,6 @@ class SymbolicBackend(Protocol[T]):
         - `ComparisonResult.unequal': 'lhs' and 'rhs' are certainly not equal.
         - `ComparisonResult.ambigous`: it is not known for certain if `lhs` and `rhs` are equal.
         """
+
+    def func(self, func_name: str) -> Callable[[...], TExpr[T]]:
+        """Obtain an implementation of a function with given name."""

--- a/src/bartiq/symbolics/backend.py
+++ b/src/bartiq/symbolics/backend.py
@@ -79,5 +79,5 @@ class SymbolicBackend(Protocol[T]):
         - `ComparisonResult.ambigous`: it is not known for certain if `lhs` and `rhs` are equal.
         """
 
-    def func(self, func_name: str) -> Callable[[...], TExpr[T]]:
+    def func(self, func_name: str) -> Callable[..., TExpr[T]]:
         """Obtain an implementation of a function with given name."""

--- a/src/bartiq/symbolics/backend.py
+++ b/src/bartiq/symbolics/backend.py
@@ -33,6 +33,9 @@ class SymbolicBackend(Protocol[T]):
     def as_expression(self, value: TExpr[T] | str) -> TExpr[T]:
         """Convert given value into an expression native to this backend."""
 
+    def as_native(self, expr: TExpr[T]) -> str | int | float:
+        """Convert given expression as an instance of a native type."""
+
     def free_symbols_in(self, expr: TExpr[T], /) -> Iterable[str]:
         """Return an iterable over free symbols in given expression."""
 

--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -205,7 +205,7 @@ class SympyBackend:
         else:
             return ComparisonResult.ambigous
 
-    def func(self, func_name: str) -> Callable[[...], TExpr[Expr]]:
+    def func(self, func_name: str) -> Callable[..., TExpr[Expr]]:
         try:
             return SPECIAL_FUNCS[func_name]
         except KeyError:

--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -205,6 +205,12 @@ class SympyBackend:
         else:
             return ComparisonResult.ambigous
 
+    def func(self, func_name: str) -> Callable[[...], TExpr[Expr]]:
+        try:
+            return SPECIAL_FUNCS[func_name]
+        except KeyError:
+            return sympy.Function(func_name)
+
 
 # Define sympy_backend for backwards compatibility
 sympy_backend = SympyBackend(parse_to_sympy)

--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -113,6 +113,10 @@ class SympyBackend:
 
         return expr
 
+    @identity_for_numbers
+    def as_native(self, expr: Expr) -> str | int | float:
+        return value if (value := self.value_of(expr)) is not None else self.serialize(expr)
+
     @empty_for_numbers
     def free_symbols_in(self, expr: Expr) -> Iterable[str]:
         """Return an iterable over free symbol names in given expression."""

--- a/tests/compilation/data/compile/general.yaml
+++ b/tests/compilation/data/compile/general.yaml
@@ -902,13 +902,13 @@
         ports:
         - direction: output
           name: out_0
-          size: '1'
+          size: 1
         type: null
       - name: b
         ports:
         - direction: input
           name: in_0
-          size: '1'
+          size: 1
         type: null
       connections:
       - source: a.out_0

--- a/tests/compilation/data/compile/passthroughs.yaml
+++ b/tests/compilation/data/compile/passthroughs.yaml
@@ -211,10 +211,10 @@
           ports:
           - direction: input
             name: in_0
-            size: '42'
+            size: 42
           - direction: output
             name: out_0
-            size: '42'
+            size: 42
           type: null
         connections:
         - source: a.out_0
@@ -225,10 +225,10 @@
         ports:
         - direction: input
           name: in_0
-          size: '42'
+          size: 42
         - direction: output
           name: out_0
-          size: '42'
+          size: 42
         type: null
       connections:
       - source: a.out_0
@@ -239,10 +239,10 @@
       ports:
       - direction: input
         name: in_0
-        size: '42'
+        size: 42
       - direction: output
         name: out_0
-        size: '42'
+        size: 42
       type: null
     version: v1
 # Propagation of param through children (this is how we introduced passthroughs)

--- a/tests/compilation/data/compile/ports_and_topology.yaml
+++ b/tests/compilation/data/compile/ports_and_topology.yaml
@@ -55,20 +55,20 @@
         ports:
         - direction: input
           name: in_0
-          size: '1'
+          size: 1
         - direction: input
           name: in_1
-          size: '2'
+          size: 2
         - direction: output
           name: out_0
-          size: '1'
+          size: 1
         - direction: output
           name: out_1
-          size: '2'
+          size: 2
         resources:
         - name: y
           type: other
-          value: '3'
+          value: 3
         type: null
       connections:
       - source: a.out_0
@@ -83,20 +83,20 @@
       ports:
       - direction: input
         name: in_0
-        size: '1'
+        size: 1
       - direction: input
         name: in_1
-        size: '2'
+        size: 2
       - direction: output
         name: out_0
-        size: '1'
+        size: 1
       - direction: output
         name: out_1
-        size: '2'
+        size: 2
       resources:
       - name: z
         type: other
-        value: '3'
+        value: 3
       type: null
     version: v1
 # Constant input register size with children inputs being described by the same variable
@@ -156,20 +156,20 @@
         ports:
         - direction: input
           name: in_0
-          size: '2'
+          size: 2
         - direction: input
           name: in_1
-          size: '2'
+          size: 2
         - direction: output
           name: out_0
-          size: '2'
+          size: 2
         - direction: output
           name: out_1
-          size: '2'
+          size: 2
         resources:
         - name: y
           type: other
-          value: '4'
+          value: 4
         type: null
       connections:
       - source: a.out_0
@@ -184,20 +184,20 @@
       ports:
       - direction: input
         name: in_0
-        size: '2'
+        size: 2
       - direction: input
         name: in_1
-        size: '2'
+        size: 2
       - direction: output
         name: out_0
-        size: '2'
+        size: 2
       - direction: output
         name: out_1
-        size: '2'
+        size: 2
       resources:
       - name: z
         type: other
-        value: '4'
+        value: 4
       type: null
     version: v1
 # Constant register size comes from non-root
@@ -236,16 +236,16 @@
         ports:
         - direction: output
           name: out_0
-          size: '1'
+          size: 1
         type: null
       - name: b
         ports:
         - direction: input
           name: in_0
-          size: '1'
+          size: 1
         - direction: output
           name: out_0
-          size: '1'
+          size: 1
         type: null
       connections:
       - source: a.out_0
@@ -256,7 +256,7 @@
       ports:
       - direction: output
         name: out_0
-        size: '1'
+        size: 1
       type: null
     version: v1
 # Parent's and child's ports are connected and the port sizes are defined in both cases (not None)
@@ -475,13 +475,13 @@
             ports:
             - direction: input
               name: in_0
-              size: '1'
+              size: 1
             - direction: input
               name: in_1
               size: N
             - direction: output
               name: out_0
-              size: '1'
+              size: 1
             - direction: output
               name: out_1
               size: N
@@ -501,13 +501,13 @@
           ports:
           - direction: input
             name: in_0
-            size: '1'
+            size: 1
           - direction: input
             name: in_1
             size: N
           - direction: output
             name: out_0
-            size: '1'
+            size: 1
           - direction: output
             name: out_1
             size: N
@@ -527,13 +527,13 @@
         ports:
         - direction: input
           name: in_0
-          size: '1'
+          size: 1
         - direction: input
           name: in_1
           size: N
         - direction: output
           name: out_0
-          size: '1'
+          size: 1
         - direction: output
           name: out_1
           size: N
@@ -553,13 +553,13 @@
       ports:
       - direction: input
         name: in_0
-        size: '1'
+        size: 1
       - direction: input
         name: in_1
         size: N
       - direction: output
         name: out_0
-        size: '1'
+        size: 1
       - direction: output
         name: out_1
         size: N

--- a/tests/compilation/data/evaluate/constants.yaml
+++ b/tests/compilation/data/evaluate/constants.yaml
@@ -15,7 +15,7 @@
       resources:
       - name: T_gates
         type: additive
-        value: '3.14159265358979'
+        value: 3.14159265358979
       type: null
     version: v1
 # Resource Q is assigned a constant value of sin(pi/2)
@@ -35,7 +35,7 @@
       resources:
       - name: T_gates
         type: additive
-        value: "1"
+        value: 1
       type: null
     version: v1
 # Resource Q is assigned a constant value of 5*e
@@ -55,6 +55,6 @@
       resources:
       - name: T_gates
         type: additive
-        value: "13.5914091422952"
+        value: 13.5914091422952
       type: null
     version: v1

--- a/tests/compilation/data/evaluate/general.yaml
+++ b/tests/compilation/data/evaluate/general.yaml
@@ -12,14 +12,14 @@
         type: other
         value: log2(x)
       type: null
-    version: v1  
+    version: v1
   - {x: 120}
   - program:
       name: root
       resources:
       - name: Q
         type: other
-        value: "6.90689059560852"
+        value: 6.90689059560852
       type: null
     version: v1
 # Port size is a function of input params, value of one param is provided for evaluation
@@ -40,7 +40,7 @@
         type: other
         value: x * y
       type: null
-    version: v1  
+    version: v1
   - {x: 42}
   - program:
       input_params:
@@ -52,7 +52,7 @@
         size: y + 42
       - direction: input
         name: out_0
-        size: "1"
+        size: 1
       resources:
       - name: Q
         type: other
@@ -89,7 +89,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "3"
+        size: 3
       - direction: input
         name: in_1
         size: M
@@ -132,7 +132,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "3"
+        size: 3
       - direction: input
         name: in_1
         size: M
@@ -209,7 +209,7 @@
         ports:
         - direction: input
           name: in_0
-          size: "3"
+          size: 3
         - direction: input
           name: in_1
           size: M
@@ -235,7 +235,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "3"
+        size: 3
       - direction: input
         name: in_1
         size: M
@@ -356,7 +356,7 @@
           ports:
           - direction: input
             name: in_0
-            size: "3"
+            size: 3
           - direction: input
             name: in_1
             size: M
@@ -365,7 +365,7 @@
             size: M + y + 5
           - direction: output
             name: out_1
-            size: "5"
+            size: 5
           resources:
           - name: Q
             type: other
@@ -387,7 +387,7 @@
         ports:
         - direction: input
           name: in_0
-          size: "3"
+          size: 3
         - direction: input
           name: in_1
           size: M
@@ -396,7 +396,7 @@
           size: M + y + 9
         - direction: output
           name: out_1
-          size: "5"
+          size: 5
         resources:
         - name: Q
           type: other
@@ -418,7 +418,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "3"
+        size: 3
       - direction: input
         name: in_1
         size: M
@@ -427,7 +427,7 @@
         size: M + y + 13
       - direction: output
         name: out_1
-        size: "5"
+        size: 5
       resources:
       - name: Q
         type: other
@@ -523,14 +523,14 @@
         ports:
         - direction: input
           name: in_0
-          size: "3"
+          size: 3
         - direction: output
           name: out_0
-          size: "5"
+          size: 5
         resources:
         - name: Q
           type: other
-          value: "6"
+          value: 6
         type: null
       - input_params:
         - y
@@ -538,7 +538,7 @@
         ports:
         - direction: input
           name: in_0
-          size: "5"
+          size: 5
         - direction: output
           name: out_0
           size: y + 5
@@ -577,7 +577,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "3"
+        size: 3
       - direction: output
         name: out_0
         size: y + 9
@@ -638,26 +638,26 @@
         ports:
         - direction: output
           name: out_0
-          size: "2"
+          size: 2
         type: null
       - name: a_1
         ports:
         - direction: output
           name: out_0
-          size: "3"
+          size: 3
         type: null
       - name: b
         ports:
         - direction: input
           name: in_0
-          size: "2"
+          size: 2
         - direction: input
           name: in_1
-          size: "3"
+          size: 3
         resources:
         - name: Q
           type: other
-          value: "5"
+          value: 5
         type: null
       connections:
       - source: a_0.out_0
@@ -684,7 +684,7 @@
       resources:
       - name: Q
         type: other
-        value: "2"
+        value: 2
       type: null
     version: v1
 # Check that expressions are simplified (for input register size assignment)
@@ -706,11 +706,11 @@
       ports:
       - direction: input
         name: in_0
-        size: "2"
+        size: 2
       resources:
       - name: Q
         type: other
-        value: "2"
+        value: 2
       type: null
     version: v1
 # Check all upstream evaluations have happened before a given downstream leaf is reached
@@ -802,10 +802,10 @@
           ports:
           - direction: input
             name: in_0
-            size: "1"
+            size: 1
           - direction: output
             name: out_0
-            size: "2"
+            size: 2
           type: null
         - input_params:
           - M
@@ -828,23 +828,23 @@
         ports:
         - direction: input
           name: in_0
-          size: "1"
+          size: 1
         - direction: input
           name: in_1
           size: M
         - direction: output
           name: out_0
-          size: "2"
+          size: 2
         type: null
       - name: x
         ports:
         - direction: input
           name: in_0
-          size: "2"
+          size: 2
         resources:
         - name: Q
           type: other
-          value: "4"
+          value: 4
         type: null
       connections:
       - source: a.out_0
@@ -859,7 +859,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "1"
+        size: 1
       - direction: input
         name: in_1
         size: M
@@ -899,13 +899,13 @@
         ports:
         - direction: output
           name: out_0
-          size: "0"
+          size: 0
         type: null
       - name: b
         ports:
         - direction: input
           name: in_0
-          size: "0"
+          size: 0
         type: null
       connections:
       - source: a.out_0
@@ -930,7 +930,7 @@
       ports:
       - direction: input
         name: in_0
-        size: "1"
+        size: 1
       type: null
     version: v1
 # Check evaluation works when local_variables contains non-trivial expression.

--- a/tests/compilation/test_evaluate.py
+++ b/tests/compilation/test_evaluate.py
@@ -116,7 +116,7 @@ def custom_function(a, b):
                     {
                         "name": "b",
                         "type": "b",
-                        "resources": [{"name": "X", "type": "other", "value": "10"}],
+                        "resources": [{"name": "X", "type": "other", "value": 10}],
                     },
                 ],
                 "resources": [{"name": "X", "type": "other", "value": "a.unknown_fun(1) + 20"}],

--- a/tests/compilation/test_preprocessing.py
+++ b/tests/compilation/test_preprocessing.py
@@ -24,17 +24,17 @@ def test_adding_additive_resources(backend):
                 "name": "a",
                 "type": None,
                 "resources": [
-                    {"name": "N_toffs", "type": "additive", "value": "1"},
-                    {"name": "N_meas", "type": "additive", "value": "5"},
+                    {"name": "N_toffs", "type": "additive", "value": 1},
+                    {"name": "N_meas", "type": "additive", "value": 5},
                 ],
             },
             {
                 "name": "b",
                 "type": None,
                 "resources": [
-                    {"name": "N_toffs", "type": "additive", "value": "2"},
-                    {"name": "N_rots", "type": "additive", "value": "3"},
-                    {"name": "N_x", "type": "other", "value": "1"},
+                    {"name": "N_toffs", "type": "additive", "value": 2},
+                    {"name": "N_rots", "type": "additive", "value": 3},
+                    {"name": "N_x", "type": "other", "value": 1},
                 ],
             },
         ],

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -98,3 +98,17 @@ def test_attempt_to_define_builtin_function_fails():
 )
 def test_single_parameters_are_correctly_recognized(expression, expected):
     assert sympy_backend.is_single_parameter(sympy_backend.as_expression(expression)) == expected
+
+
+@pytest.mark.parametrize(
+    "expression_str, expected_value", [("N", "N"), ("k * j + i", "i + j*k"), ("2.5", 2.5), ("4", 4)]
+)
+def test_expressions_are_correctly_converted_to_native_types_based_on_their_category(
+    expression_str, expected_value, backend
+):
+    expr = backend.as_expression(expression_str)
+
+    native_value = backend.as_native(expr)
+
+    assert isinstance(native_value, type(expected_value))  # Needed because e.g. 4.0 == 4, value is not enough
+    assert native_value == expected_value

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -112,3 +112,18 @@ def test_expressions_are_correctly_converted_to_native_types_based_on_their_cate
 
     assert isinstance(native_value, type(expected_value))  # Needed because e.g. 4.0 == 4, value is not enough
     assert native_value == expected_value
+
+
+@pytest.mark.parametrize(
+    "func_name, arg_str, expected_native_result",
+    [("ceil", 2, 2), ("sin", "PI", 0), ("sin", "x", "sin(x)"), ("sin", "PI/6", 0.5)],
+)
+def test_functions_obtained_from_backend_can_be_called_to_obtain_new_expressions(
+    func_name, arg_str, expected_native_result, backend
+):
+    func = backend.func(func_name)
+    arg = backend.as_expression(arg_str)
+
+    result = func(arg)
+
+    assert backend.as_native(result) == expected_native_result


### PR DESCRIPTION
## Description

While working on several features, we noticed that there are some limitations to the backend interface, namely:

1. It is not possible to obtain native Python objects from expressions. There is a `serialize` method that always returns string, and there is `value_of` method that either returns a number OR `None` if it is not possible to convert an expression to number. There is no single function that would convert expressions representing numbers to numbers, and other expressions to strings.
2. While manipulating symbolic expressions is easy through arithmetic operators, there's not really a way for applying function to symbolic expressions. The current solution involves going through `backend.as_expression`, e.g.: `backend.as_expression(f"sin({backend.serialize(some_expr)})")` which a) is not very readable , b) incurs a performance penalty if `some_expr` is long and complicated.

This PR solves both of this issues by defining `backend.as_native(expr)` and `backend.func(func_name)` methods.

The `backend.func` can be used as follows:
```python
x = .... # Assume we have some expression for x
sin = backend.func("sin")
result = sin(x). # This is of type TExpr[T] (for backend specialized to T
```
The name `func_name` was chosen instead of e.g. `backend.function` so that we have more concise notation while still maintining a reasonable level of readability.


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.