### PR TITLE
fix: Fix defining function in case some of them evaluate to constant

### DIFF
--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -67,6 +67,15 @@ def empty_for_numbers(func: ExprTransformer[P, Iterable[T]]) -> TExprTransformer
 
 
 def identity_for_numbers(func: ExprTransformer[P, T | Number]) -> TExprTransformer[P, T | Number]:
+    """Return a new method that preserves originally passed one on expressions and acts as identity on numbers.
+
+    Note:
+        This function can ONLY be used on methods of SympyBackend class.
+        If you want to use it on a function, add dummy `_backend` parameter as a first arg - but do know
+        that this is discouraged. Incorrect usage of this decorator on an ordinary function resulted
+        in an obscure bug: https://github.com/PsiQ/bartiq/issues/143
+    """
+
     def _inner(backend: SympyBackend, expr: TExpr[S], *args: P.args, **kwargs: P.kwargs) -> T | Number:
         return expr if isinstance(expr, Number) else func(backend, expr, *args, **kwargs)
 

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -133,7 +133,7 @@ def test_functions_obtained_from_backend_can_be_called_to_obtain_new_expressions
     "expression_str, variables, functions, expected_native_result",
     [
         ("8", {}, {"f": lambda x: x + 10}, 8),
-        ("f(x)", {"x": 5}, {"f": lambda x: 10, "g": lambda x: x}, 5),
+        ("f(x)", {"x": 5}, {"f": lambda x: int(x) + 5, "g": lambda x: x}, 10),
         ("f(x)+10", {}, {"f": lambda x: 2, "g": lambda x: int(x) ** 2}, 12),
     ],
 )

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -127,3 +127,21 @@ def test_functions_obtained_from_backend_can_be_called_to_obtain_new_expressions
     result = func(arg)
 
     assert backend.as_native(result) == expected_native_result
+
+
+@pytest.mark.parametrize(
+    "expression_str, variables, functions, expected_native_result",
+    [
+        ("8", {}, {"f": lambda x: x + 10}, 8),
+        ("f(x)", {"x": 5}, {"f": lambda x: 10, "g": lambda x: x}, 5),
+        ("f(x)+10", {}, {"f": lambda x: 2, "g": lambda x: int(x) ** 2}, 12),
+    ],
+)
+def test_function_definition_succeeds_even_if_expression_becomes_constant(
+    expression_str, variables, functions, expected_native_result, backend
+):
+    expr = backend.as_expression(expression_str)
+
+    new_expr = backend.substitute(expr, variables, functions)
+
+    assert backend.as_native(new_expr) == expected_native_result

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -133,6 +133,8 @@ def test_functions_obtained_from_backend_can_be_called_to_obtain_new_expressions
     "expression_str, variables, functions, expected_native_result",
     [
         ("8", {}, {"f": lambda x: x + 10}, 8),
+        # Note: existence of function "g" is crucial in the examples below, even if it is not used explicitly
+        # These examples triggered issue #143: https://github.com/PsiQ/bartiq/issues/143
         ("f(x)", {"x": 5}, {"f": lambda x: int(x) + 5, "g": lambda x: x}, 10),
         ("f(x)+10", {}, {"f": lambda x: 2, "g": lambda x: int(x) ** 2}, 12),
     ],


### PR DESCRIPTION
## Description

Fixes bug described in #143. The fix is achieved by correcting the usage of `identity_for_numbers`.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.