### PR TITLE
fix: Substitution of functions is no longer sensitive to order of functions dictionary

### DIFF
--- a/src/bartiq/integrations/latex.py
+++ b/src/bartiq/integrations/latex.py
@@ -18,7 +18,7 @@ from operator import attrgetter
 from qref.schema_v1 import ParamLinkV1, PortV1, ResourceV1, RoutineV1, SchemaV1
 from sympy import latex, symbols
 
-from ..symbolics.sympy_interpreter import parse_to_sympy
+from ..symbolics.sympy_backends import parse_to_sympy
 
 
 def routine_to_latex(routine: SchemaV1 | RoutineV1, show_non_root_resources: bool = True) -> str:

--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -96,7 +96,7 @@ def parse_to_sympy(expression: str, debug: bool = False) -> Expr:
 
 
 def _sympify_function(func_name: str, func: Callable) -> type[sympy.Function]:
-    if not issubclass(type(func), sympy.Function):
+    if not isinstance(func, sympy.Function):
 
         def _eval_wrapper(cls, *args, **kwargs):
             try:

--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -101,7 +101,7 @@ def _sympify_function(func_name: str, func: Callable) -> type[sympy.Function]:
         def _eval_wrapper(cls, *args, **kwargs):
             try:
                 return func(*args, **kwargs)
-            # The except claus here is intentionally broad, you never know what
+            # The except clause here is intentionally broad, you never know what
             # func can raise.
             except Exception:
                 return None

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -147,3 +147,19 @@ def test_function_definition_succeeds_even_if_expression_becomes_constant(
     new_expr = backend.substitute(expr, variables, functions)
 
     assert backend.as_native(new_expr) == expected_native_result
+
+
+def test_defining_functions_is_invariant_under_input_order(backend):
+    def f(x):
+        return int(x) + 1
+
+    def g(x):
+        return x**2
+
+    expr = backend.as_expression("f(g(x))")
+
+    result_1 = backend.substitute(expr, {"x": 3}, {"f": f, "g": g})
+    result_2 = backend.substitute(expr, {"x": 3}, {"g": g, "f": f})
+
+    assert result_1 == 10
+    assert result_2 == 10

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -14,6 +14,7 @@
 
 
 import math
+import warnings
 
 import pytest
 import sympy
@@ -25,11 +26,6 @@ from bartiq.analysis import BigO, minimize
 @pytest.mark.parametrize(
     "expr,variable,expected",
     [
-        (
-            x**y + y**x + x * y + x**2 * y + 3 + x * y**2 + x + y + 1,
-            None,
-            BigO(x**y) + BigO(y**x) + BigO(x * y**2) + BigO(x**2 * y),
-        ),
         (
             x * y + x**2 * y + 3 + x * y**3 + x + y + 1,
             x,
@@ -45,14 +41,31 @@ from bartiq.analysis import BigO, minimize
             y,
             BigO(y),
         ),
+    ],
+)
+def test_BigO(expr, variable, expected):
+    assert BigO(expr, variable) == expected
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", "Results for using BigO")
+    MULTIVARIATE_TEST_CASES = [
         (
             sympy.sympify("log(x) + y**2 + y"),
             None,
             BigO(sympy.sympify("log(x)")) + BigO(y**2),
         ),
-    ],
-)
-def test_BigO(expr, variable, expected):
+        (
+            x**y + y**x + x * y + x**2 * y + 3 + x * y**2 + x + y + 1,
+            None,
+            BigO(x**y) + BigO(y**x) + BigO(x * y**2) + BigO(x**2 * y),
+        ),
+    ]
+
+
+@pytest.mark.filterwarnings(r"ignore:Results for using BigO")
+@pytest.mark.parametrize("expr,variable,expected", MULTIVARIATE_TEST_CASES)
+def test_multivariate_BigO(expr, variable, expected):
     assert BigO(expr, variable) == expected
 
 
@@ -64,6 +77,7 @@ def test_BigO_throws_warning_for_multiple_variables():
         BigO(x**y + y**x + x * y + x**2 * y + 3 + x * y**2 + x + y + 1)
 
 
+@pytest.mark.filterwarnings(r"ignore:Results for using BigO")
 def test_adding_BigO_expressions():
     assert BigO(x) + BigO(x) == BigO(x)
     assert BigO(x) * BigO(x) == BigO(x**2)
@@ -158,7 +172,7 @@ def test_minimize_gradient_descent(
             {
                 "method": "L-BFGS-B",
                 "tol": 1e-6,
-                "options": {"disympy": False},
+                "options": {"disp": False},
             },
             math.pi,
             -1.0,
@@ -175,7 +189,7 @@ def test_minimize_gradient_descent(
             {
                 "method": "Nelder-Mead",
                 "tol": 1e-6,
-                "options": {"disympy": False},
+                "options": {"disp": False},
             },
             0.0,
             0.0,


### PR DESCRIPTION
## Description

Closes #146 

The problem was solved by dynamically defining proper sympy functions that can be evaluated when needed instead of relying on a success of a single call to the user defined function.

Additionally, this PR contains a boy-scout cleanup of the warnings raised in all our tests. At least when tested locally, the tests don't emit any warnings. Most warnings were just filtered out (as they are known and expected warnings), two of them were fixed because they resulted from typo.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.