### PR TITLE
feat: add min and max to backend

### DIFF
--- a/src/bartiq/errors.py
+++ b/src/bartiq/errors.py
@@ -17,5 +17,9 @@ class BartiqPreprocessingError(Exception):
     """Raised for errors during Bartiq function pre-processing."""
 
 
+class BartiqPostprocessingError(Exception):
+    """Raised for errors during Bartiq function post-processing."""
+
+
 class BartiqCompilationError(Exception):
     """Raised for errors during Bartiq function compilation."""

--- a/src/bartiq/repetitions.py
+++ b/src/bartiq/repetitions.py
@@ -166,10 +166,10 @@ class CustomSequence(Generic[T]):
     iterator_symbol: T
 
     def get_sum(self, expr: TExpr[T], count: TExpr[T], backend: SymbolicBackend[T]) -> TExpr[T]:
-        return backend.sum(self.term_expression * expr, self.iterator_symbol, 0, count - 1)
+        return backend.sequence_sum(self.term_expression * expr, self.iterator_symbol, 0, count - 1)
 
     def get_prod(self, expr: TExpr[T], count: TExpr[T], backend: SymbolicBackend[T]) -> TExpr[T]:
-        return backend.prod(self.term_expression * expr, self.iterator_symbol, 0, count - 1)
+        return backend.sequence_prod(self.term_expression * expr, self.iterator_symbol, 0, count - 1)
 
     def substitute_symbols(
         self, inputs: dict[str, TExpr[T]], backend: SymbolicBackend[T], functions_map=None

--- a/src/bartiq/symbolics/backend.py
+++ b/src/bartiq/symbolics/backend.py
@@ -82,8 +82,14 @@ class SymbolicBackend(Protocol[T]):
     def func(self, func_name: str) -> Callable[..., TExpr[T]]:
         """Obtain an implementation of a function with given name."""
 
-    def sum(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
+    def min(self, *args):
+        """Returns a smallest value from given args."""
+
+    def max(self, *args):
+        """Returns a biggest value from given args."""
+
+    def sequence_sum(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
         """Express a sum of terms expressed using `iterator_symbol`."""
 
-    def prod(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
+    def sequence_prod(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
         """Express a product of terms expressed using `iterator_symbol`."""

--- a/src/bartiq/symbolics/sympy_backends.py
+++ b/src/bartiq/symbolics/sympy_backends.py
@@ -248,11 +248,19 @@ class SympyBackend:
         except KeyError:
             return sympy.Function(func_name)
 
-    def sum(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
+    def min(self, *args):
+        """Returns a smallest value from given args."""
+        return sympy.Min(*args)
+
+    def max(self, *args):
+        """Returns a biggest value from given args."""
+        return sympy.Max(*args)
+
+    def sequence_sum(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
         """Express a sum of terms expressed using `iterator_symbol`."""
         return sympy.Sum(term, (iterator_symbol, start, end))
 
-    def prod(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
+    def sequence_prod(self, term: TExpr[T], iterator_symbol: TExpr[T], start: TExpr[T], end: TExpr[T]) -> TExpr[T]:
         """Express a product of terms expressed using `iterator_symbol`."""
         return sympy.Product(term, (iterator_symbol, start, end))
 

--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -26,6 +26,7 @@ BACKEND = sympy_backend
 
 
 T = TypeVar("T")
+# NOTE: Actually, it should be `Routine[T]` and `CompiledRoutine[T]`, but such syntax is not currently supported.
 AnyRoutine = TypeVar("AnyRoutine", Routine, CompiledRoutine)
 
 

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -11,7 +11,10 @@ Tests for the SympyExpression implementation.
 """
 
 import pytest
-from sympy import E, cos, exp, pi, sin, sqrt, sympify
+from sympy import E
+from sympy import Max as sympy_max
+from sympy import Min as sympy_min
+from sympy import cos, exp, pi, sin, sqrt, symbols, sympify
 
 from bartiq.errors import BartiqCompilationError
 from bartiq.symbolics import sympy_backend
@@ -163,3 +166,15 @@ def test_defining_functions_is_invariant_under_input_order(backend):
 
     assert result_1 == 10
     assert result_2 == 10
+
+
+def test_min_max_works_for_numerical_values(backend):
+    values = [-5, 0, 1, 23.4]
+    assert backend.min(*values) == min(*values)
+    assert backend.max(*values) == max(*values)
+
+
+def test_min_max_works_for_symbols(backend):
+    values = symbols("a, b, c")
+    assert backend.min(*values) == sympy_min(*values)
+    assert backend.max(*values) == sympy_max(*values)


### PR DESCRIPTION
## Description

Adds min and max functions to symbolic backend and refactors `sum` to `sequence_sum` (and same for `prod`).

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have included test cases validating introduced feature/fix.
- [X] I have updated documentation.