### PR TITLE
fix: add escape for _ in local_variables in latex

### DIFF
--- a/src/bartiq/integrations/latex.py
+++ b/src/bartiq/integrations/latex.py
@@ -166,6 +166,7 @@ def _format_param_math(param: str) -> str:
 def _format_param_math_with_subscript(param: str) -> str:
     """Formats a subscripted param as math."""
     symbol, subscript = param.split("_", 1)
+    subscript = subscript.replace("_", r"\_")
     subscript_latex = latex(symbols(subscript))
     symbol_latex = latex(symbols(symbol))
 

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -93,10 +93,7 @@ LATEX_TEST_CASES = [
         RoutineV1(
             name="root",
             input_params=["a", "b"],
-            local_variables={
-                "x_foo": "y + a",
-                "y_bar": "b * c",
-            },
+            local_variables={"x_foo": "y + a", "y_bar": "b * c", "z_foo_bar": "a + b"},
         ),
         {},
         r"""
@@ -105,7 +102,8 @@ LATEX_TEST_CASES = [
 &a, b\newline
 &\underline{\text{Local variables:}}\\
 &x_{\text{foo}} = a + y\\
-&y_{\text{bar}} = b \cdot c
+&y_{\text{bar}} = b \cdot c\\
+&z_{\text{foo\_bar}} = a + b
 """,
     ),
     # Only output ports

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -93,7 +93,11 @@ LATEX_TEST_CASES = [
         RoutineV1(
             name="root",
             input_params=["a", "b"],
-            local_variables={"x_foo": "y + a", "y_bar": "b * c", "z_foo_bar": "a + b"},
+            local_variables={
+                "x_foo": "y + a",
+                "y_bar": "b * c",
+                "z_foo_bar": "a + b",
+            },
         ),
         {},
         r"""


### PR DESCRIPTION
## Description

Fixes issue when we try to render in latex routine where one of the local variables has multiple underscores.