### PR TITLE
Support port sizes when rendering with latex

### DIFF
--- a/src/bartiq/integrations/jupyter/routine_explorer.py
+++ b/src/bartiq/integrations/jupyter/routine_explorer.py
@@ -22,9 +22,6 @@ from ..latex import routine_to_latex
 
 DEFAULT_ROOT_NAME = ""
 
-# TODO (SMS): Yes, I know this is bad.
-MAX_RESOURCE_SECTIONS = 9
-
 
 class _RoutineTree(Tree):
     """Tree object representing Routine."""

--- a/src/bartiq/integrations/jupyter/routine_explorer.py
+++ b/src/bartiq/integrations/jupyter/routine_explorer.py
@@ -15,6 +15,7 @@
 import ipywidgets as widgets
 from ipytree import Node, Tree
 from qref import SchemaV1
+from qref.functools import accepts_all_qref_types
 from qref.schema_v1 import RoutineV1
 from traitlets import Tuple
 
@@ -70,9 +71,8 @@ class _RoutineTree(Tree):
             self.routine_data = tuple(widgets.HTMLMath(rf"{html_string}") for html_string in html_strings)
 
 
-def explore_routine(
-    routine: SchemaV1 | RoutineV1, tree_min_width="initial", resource_max_width="initial"
-) -> widgets.HBox:
+@accepts_all_qref_types
+def explore_routine(routine: RoutineV1, tree_min_width="initial", resource_max_width="initial") -> widgets.HBox:
     """Widget faciliting exploration of routine's costs.
 
     Args:

--- a/src/bartiq/integrations/latex.py
+++ b/src/bartiq/integrations/latex.py
@@ -106,7 +106,13 @@ def _format_output_port_sizes(ports: Iterable[PortV1]) -> str:
 
 
 def _format_port_sizes(ports: Iterable[PortV1], label: str) -> str:
-    lines = [f"&{_format_name_text(port.name)} = {_latex_expression(str(port.size))}" for port in ports]
+    lines = []
+
+    for port in ports:
+        port_size_string = _latex_expression(str(port.size)) if port.size is not None else "None"
+        line = f"&{_format_name_text(port.name)} = {port_size_string}"
+        lines.append(line)
+
     return _format_section_multi_line(f"{label} ports", lines)
 
 

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -305,6 +305,24 @@ LATEX_TEST_CASES = [
 &\text{a}.\!y = 2
 """,
     ),
+    # Handle null-sized ports
+    (
+        RoutineV1(
+            name="root",
+            ports=[
+                {"name": "in_0", "size": None, "direction": "input"},
+                {"name": "out_0", "size": None, "direction": "output"},
+            ],
+        ),
+        {},
+        r"""
+&\text{RoutineV1 \textrm{(root)}}\newline
+&\underline{\text{Input ports:}}\\
+&\text{in\_0} = None\newline
+&\underline{\text{Output ports:}}\\
+&\text{out\_0} = None
+""",
+    ),
 ]
 
 


### PR DESCRIPTION
## Description

I was finding an error when trying to explore uncompiled routines with port sizes set to `None`. The previous implementation was passing these into sympy as strings, which was causing an error during sympy's evaluation.

This simply handles those cases by bypassing the sympy-expression-to-latex pass.

In addition, the following boyscout changes were made:
1. Removing the unused constant `MAX_RESOURCE_SECTIONS`, which I introduced accidentally in a previous PR.
2. Decorates `explore_routine` with `accepts_all_qref_types`.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] ~I have updated documentation.~ N/A