### PR TITLE
fix: Ensure highwater is 0 for empty routines

### DIFF
--- a/src/bartiq/compilation/postprocessing.py
+++ b/src/bartiq/compilation/postprocessing.py
@@ -80,7 +80,8 @@ def _compute_highwater(
     local_ancillae = routine.resources[ancillae_name].value if ancillae_name in routine.resources else 0
 
     nonzero_watermarks = [watermark for watermark in watermarks if watermark != 0]
-    return backend.max(*nonzero_watermarks) + local_ancillae
+
+    return backend.max(*nonzero_watermarks) + local_ancillae if nonzero_watermarks else local_ancillae
 
 
 @postorder_transform

--- a/tests/compilation/test_postprocessing.py
+++ b/tests/compilation/test_postprocessing.py
@@ -169,3 +169,11 @@ def test_computing_highwater_for_non_chronologically_sorted_routine_raises_warni
         )
     ):
         _ = compile_routine(input_routine, postprocessing_stages=[add_qubit_highwater])
+
+
+def test_highwater_of_an_empty_routine_is_zero():
+    input_routine = {"version": "v1", "program": {"name": "root"}}
+
+    compiled_routine = compile_routine(input_routine, postprocessing_stages=[add_qubit_highwater]).routine
+
+    assert compiled_routine.resources["qubit_highwater"].value == 0


### PR DESCRIPTION
## Description

In the current implementation, he highwater for an empty routine is -infinity. That's because for such a routine the list of nonzero watermarks is empty, and in sympy maximum of an empty list is is -infinity. This is not a big problem, but it may make highwater look strange for some virtual routines, so this PR introduces a safeguard against that.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.