### PR TITLE
Refactoring pow operations

### DIFF
--- a/src/bartiq/symbolics/ast_parser.py
+++ b/src/bartiq/symbolics/ast_parser.py
@@ -60,7 +60,7 @@ _BINARY_OP_MAP = {
     ast.Sub: operator.sub,
     ast.Mod: operator.mod,
     ast.Pow: operator.pow,
-    ast.BitXor: operator.pow,
+    ast.BitXor: operator.xor,
     ast.FloorDiv: operator.floordiv,
 }
 

--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -68,7 +68,7 @@ BINARY_OPS = {
     "*": operator.mul,
     "/": operator.truediv,
     "//": operator.floordiv,
-    "^": operator.pow,
+    "^": operator.xor,
     "**": operator.pow,
     "%": operator.mod,
 }


### PR DESCRIPTION
## Description

Fixing #138 


- Context: Discussion to refactor Bartiq to represent `pow` operations with `**` instead of `^` in [Here](https://github.com/PsiQ/qref/pull/124#discussion_r1830899552)
- definition `_contains_xor_op()`  and `_replace_xor_op()` was provided already to fix this issue

Fixed:
- `ast_parser.py` still contain `ast.BitXor: operator.pow` which was changed to `xor` operation
- Updated `sympy_interpreter.py` operator method for `^`

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.