### PR TITLE
feat: created `CompilationFlags` enum

### DIFF
--- a/docs/concepts/compilation.md
+++ b/docs/concepts/compilation.md
@@ -118,11 +118,22 @@ to the repetition rules; the repetition specification itself gets updated using 
 
 At this stage each child should have input and through ports defined in terms of global variables, and we can now compile the resources. Parents have their resources updated from the compiled resources of their children.
 
-By default, we compile resources *transitively* with the compilation flag `allow_transitive_resources=True` in the `compile_routine` function call. This means that the resources of a particular routine are defined only in terms of the relevant contributions from their immedite children, and any expressions defined locally. For instance, an additive resource `X` in a routine `Parent` might have the following value _after_ compilation:
-```
+By default, we compile resources *transitively* such that the resources of a particular routine are defined only in terms of the relevant contributions from their immedite children, and any expressions defined locally. For instance, an additive resource `X` in a routine `Parent` might have the following value _after_ compilation:
+```python
 Parent.resources['X'].value = Child_a.X + Child_b.X + Child_c.X
 ```
-By setting `allow_transitive_resources=False` when calling `compile_routine`, these expressions are expanded into full symbolic or numeric expressions.
+This provides a performance boost when routines have multiple routines and subroutines, and expressions become unweildy. 
+
+To override this, we can pass in a _compilation flag_ into the `compile_routine` function call:
+```python
+from bartiq.compilation import CompilationFlags
+
+compile_routine(..., compilation_flags=CompilationFlags.EXPAND_RESOURCES)
+```
+Alternatively, we can call `evaluate` on the resultant compiled routine with no variable assignments to expand the resources:
+```python
+expanded_resources_routine = evaluate(routine_compiled_transitively, {})
+```
 
 #### Step 2.8: Output port compilation
 

--- a/docs/concepts/compilation.md
+++ b/docs/concepts/compilation.md
@@ -59,7 +59,7 @@ Currently, the  following preprocessing stages take place prior to compilation:
 1. Propagation of linked params. In this stage all linked parameters reaching further than a direct
    descendant are converted into a series of direct parameter links. This is useful because you can, for example,
    link a parameter from the top-level routine to a parameter arbitrarily deep in the program structure. This is will compile correctly, despite `bartiq`'s compilation engine requirement on having only direct links.
-2. Promotion of unlinked inputs. Compilation cannot handle parameters that are not linked or pased through
+2. Promotion of unlinked inputs. Compilation cannot handle parameters that are not linked or passed through
    connections. To avoid unnecessary compilation errors, `bartiq` will promote such parameters by linking it to newly introduced input in the parent routine.
 3. Introduction of port variables. As discussed above, this step converts all ports so that they have sizes
    equal to a single-parameter expression of known name, while also introducing constraints to make sure
@@ -117,6 +117,12 @@ to the repetition rules; the repetition specification itself gets updated using 
 #### Step 2.7: Resource compilation
 
 At this stage each child should have input and through ports defined in terms of global variables, and we can now compile the resources. Parents have their resources updated from the compiled resources of their children.
+
+By default, we compile resources *transitively* with the compilation flag `allow_transitive_resources=True` in the `compile_routine` function call. This means that the resources of a particular routine are defined only in terms of the relevant contributions from their immedite children, and any expressions defined locally. For instance, an additive resource `X` in a routine `Parent` might have the following value _after_ compilation:
+```
+Parent.resources['X'].value = Child_a.X + Child_b.X + Child_c.X
+```
+By setting `allow_transitive_resources=False` when calling `compile_routine`, these expressions are expanded into full symbolic or numeric expressions.
 
 #### Step 2.8: Output port compilation
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,6 +4,8 @@
 
 ::: bartiq.analysis
 
+::: bartiq.compilation
+
 ::: bartiq.symbolics
 
 ::: bartiq.errors

--- a/docs/tutorials/01_basic_example.ipynb
+++ b/docs/tutorials/01_basic_example.ipynb
@@ -397,7 +397,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x108693380>"
+       "<graphviz.graphs.Digraph at 0x12233a7b0>"
       ]
      },
      "execution_count": 8,
@@ -622,14 +622,12 @@
    "source": [
     "Since the resources in the children have type `additive`, `bartiq` automatically added the `T_gates` resource to the parent as a sum of the resources of the children.\n",
     "\n",
-    "The reason the total T gates value is represented as a sum of `child.resource` strings is due to a compilation flag `allow_transitive_resources`, which is set to `True` by default. \n",
-    "\n",
-    "If we recompile the routine with this set to `False`, we will obtain a full expression:\n"
+    "The reason the total T gates value is represented as a sum of `child.resource` strings is due to our default compilation process, such that resources are compiled _transitively_. To override this, we can pass a **compilation flag**. \n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "67ef48b2",
    "metadata": {},
    "outputs": [
@@ -642,7 +640,9 @@
     }
    ],
    "source": [
-    "compiled_routine = compile_routine(my_algorithm_qref, allow_transitive_resources=False).routine\n",
+    "from bartiq.compilation import CompilationFlags\n",
+    "\n",
+    "compiled_routine = compile_routine(my_algorithm_qref, compilation_flags=CompilationFlags.EXPAND_RESOURCES).routine\n",
     "print(\"Total T gates:\", compiled_routine.resources[\"T_gates\"].value)"
    ]
   },
@@ -666,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "4c232bc3-77bb-4bd8-a587-b6591d539c41",
    "metadata": {
     "ExecuteTime": {

--- a/docs/tutorials/01_basic_example.ipynb
+++ b/docs/tutorials/01_basic_example.ipynb
@@ -397,7 +397,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x1067b6690>"
+       "<graphviz.graphs.Digraph at 0x108693380>"
       ]
      },
      "execution_count": 8,
@@ -605,7 +605,7 @@
      "text": [
       "T gates for A: 2*n + z\n",
       "Output size: 2*n + z\n",
-      "Total T gates: 2*n*z*ceiling(log2(2*n)) + 2*n + z\n"
+      "Total T gates: A.T_gates + B.T_gates\n"
      ]
     }
    ],
@@ -620,7 +620,30 @@
    "id": "b5ebbf43-ab27-47c7-ab8c-876c6e4cd390",
    "metadata": {},
    "source": [
-    "Since the resources in the children have type `additive`, `bartiq` automatically added the `T_gates` resource to the parent as a sum of the resources of the children."
+    "Since the resources in the children have type `additive`, `bartiq` automatically added the `T_gates` resource to the parent as a sum of the resources of the children.\n",
+    "\n",
+    "The reason the total T gates value is represented as a sum of `child.resource` strings is due to a compilation flag `allow_transitive_resources`, which is set to `True` by default. \n",
+    "\n",
+    "If we recompile the routine with this set to `False`, we will obtain a full expression:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "67ef48b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total T gates: 2*n*z*ceiling(log2(2*n)) + 2*n + z\n"
+     ]
+    }
+   ],
+   "source": [
+    "compiled_routine = compile_routine(my_algorithm_qref, allow_transitive_resources=False).routine\n",
+    "print(\"Total T gates:\", compiled_routine.resources[\"T_gates\"].value)"
    ]
   },
   {
@@ -643,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "id": "4c232bc3-77bb-4bd8-a587-b6591d539c41",
    "metadata": {
     "ExecuteTime": {
@@ -724,7 +747,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/02_alias_sampling_basic.ipynb
+++ b/docs/tutorials/02_alias_sampling_basic.ipynb
@@ -654,7 +654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "d20ef4d2-9420-4090-a402-ee5f27034524",
    "metadata": {
     "ExecuteTime": {
@@ -665,8 +665,9 @@
    "outputs": [],
    "source": [
     "from bartiq import compile_routine\n",
+    "from bartiq.compilation import CompilationFlags\n",
     "\n",
-    "compiled_routine = compile_routine(uncompiled_routine, allow_transitive_resources=False).routine"
+    "compiled_routine = compile_routine(uncompiled_routine, compilation_flags=CompilationFlags.EXPAND_RESOURCES).routine"
    ]
   },
   {

--- a/docs/tutorials/02_alias_sampling_basic.ipynb
+++ b/docs/tutorials/02_alias_sampling_basic.ipynb
@@ -625,7 +625,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x107a01520>"
+       "<graphviz.graphs.Digraph at 0x1098463c0>"
       ]
      },
      "execution_count": 8,
@@ -666,7 +666,7 @@
    "source": [
     "from bartiq import compile_routine\n",
     "\n",
-    "compiled_routine = compile_routine(uncompiled_routine).routine"
+    "compiled_routine = compile_routine(uncompiled_routine, allow_transitive_resources=False).routine"
    ]
   },
   {
@@ -758,7 +758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "2909fb37-6a15-44fc-a80f-46e562220fcb",
    "metadata": {
     "ExecuteTime": {
@@ -812,13 +812,13 @@
     "\n",
     "<div class=\"alert alert-block alert-info admonition note\"> <p class=\"admonition-title\"><b>NOTE:</b></p>\n",
     "This is an interactive feature and will not render in the static version of the docs. To use it you need to run this tutorial as a jupyter notebook. <br>\n",
-    "Remember to install bartiq with <code>pip install bartiq[jupyter]</code> to make sure you have all the dependencies needed for these widgets to work (for more details visit <a href=\"https://psiq.github.io/bartiq/latest/installation/\">installation docs</a>).\n",
+    "Remember to install bartiq with <code>pip install 'bartiq[jupyter]'</code> to make sure you have all the dependencies needed for these widgets to work (for more details visit <a href=\"https://psiq.github.io/bartiq/latest/installation/\">installation docs</a>).\n",
     "</div>\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "1a346534-4f97-4855-8262-2c5df824eb27",
    "metadata": {
     "ExecuteTime": {
@@ -830,12 +830,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c948e5235cbc4d7795c080fde50b15ad",
+       "model_id": "09cdd60a851b42c8a76e669269d90a52",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(_RoutineTree(multiple_selection=False, nodes=(Node(name='alias_sampling', nodes=(Node(name='com…"
+       "HBox(children=(VBox(children=(_RoutineTree(multiple_selection=False, nodes=(Node(name='alias_sampling', nodes=…"
       ]
      },
      "execution_count": 13,
@@ -859,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "a925abe0-9026-4079-9c5a-8ef5e087a551",
    "metadata": {
     "ExecuteTime": {
@@ -888,11 +888,11 @@
        "&\\underline{\\text{Resources:}}\\\\\n",
        "&T_{\\text{gates}} = 535\\\\\n",
        "&rotations = 2\\\\\n",
-       "&\\text{compare}.\\!T_{\\text{gates}} = 28\\\\\n",
-       "&\\text{qrom}.\\!T_{\\text{gates}} = 476\\\\\n",
-       "&\\text{swap}.\\!T_{\\text{gates}} = 7\\\\\n",
        "&\\text{usp}.\\!T_{\\text{gates}} = 24\\\\\n",
-       "&\\text{usp}.\\!rotations = 2\n",
+       "&\\text{usp}.\\!rotations = 2\\\\\n",
+       "&\\text{qrom}.\\!T_{\\text{gates}} = 476\\\\\n",
+       "&\\text{compare}.\\!T_{\\text{gates}} = 28\\\\\n",
+       "&\\text{swap}.\\!T_{\\text{gates}} = 7\n",
        "\\end{align}$"
       ],
       "text/plain": [
@@ -935,7 +935,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "bartiq-NENgNB9d-py3.12",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -949,7 +949,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/03_advanced_examples.ipynb
+++ b/docs/tutorials/03_advanced_examples.ipynb
@@ -842,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "b2c326da-143f-448f-99ec-390f41f537ff",
    "metadata": {},
    "outputs": [
@@ -858,8 +858,9 @@
    ],
    "source": [
     "from bartiq import compile_routine\n",
+    "from bartiq.compilation import CompilationFlags\n",
     "\n",
-    "compiled_usp = compile_routine(uncompiled_usp, allow_transitive_resources=False).routine\n",
+    "compiled_usp = compile_routine(uncompiled_usp, compilation_flags=CompilationFlags.EXPAND_RESOURCES).routine\n",
     "for resource in compiled_usp.resources.values():\n",
     "    print(f\"{resource.name}: {resource.value}\")"
    ]

--- a/docs/tutorials/03_advanced_examples.ipynb
+++ b/docs/tutorials/03_advanced_examples.ipynb
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "2be3a3b17fe69e9e",
    "metadata": {
     "ExecuteTime": {
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "3fd285365d9bcef2",
    "metadata": {
     "ExecuteTime": {
@@ -424,7 +424,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x1039dfb00>"
+       "<graphviz.graphs.Digraph at 0x107f423c0>"
       ]
      },
      "execution_count": 6,
@@ -810,7 +810,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x104a8c8f0>"
+       "<graphviz.graphs.Digraph at 0x107eebe30>"
       ]
      },
      "execution_count": 8,
@@ -859,7 +859,7 @@
    "source": [
     "from bartiq import compile_routine\n",
     "\n",
-    "compiled_usp = compile_routine(uncompiled_usp).routine\n",
+    "compiled_usp = compile_routine(uncompiled_usp, allow_transitive_resources=False).routine\n",
     "for resource in compiled_usp.resources.values():\n",
     "    print(f\"{resource.name}: {resource.value}\")"
    ]
@@ -1038,7 +1038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "72b6f5db-eb16-4b49-9a10-1ea5ade7e817",
    "metadata": {
     "ExecuteTime": {
@@ -1968,7 +1968,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "bartiq-NENgNB9d-py3.12",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1982,7 +1982,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/src/bartiq/compilation/__init__.py
+++ b/src/bartiq/compilation/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._compile import CompilationResult, compile_routine
+from ._compile import CompilationFlags, CompilationResult, compile_routine
 from ._evaluate import EvaluationResult, evaluate
 
-__all__ = ["compile_routine", "CompilationResult", "evaluate", "EvaluationResult"]
+__all__ = ["compile_routine", "CompilationResult", "evaluate", "EvaluationResult", "CompilationFlags"]

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -294,7 +294,7 @@ def _compile(
     inputs: dict[str, TExpr[T]],
     context: Context,
     derived_resources: Iterable[DerivedResources] = (),
-    compilation_flags: CompilationFlags = CompilationFlags(0),
+    compilation_flags: CompilationFlags = CompilationFlags(0),  # CompilationsFlags(0) corresponds to no flags
 ) -> CompiledRoutine[T]:
     try:
         new_constraints = evaluate_constraints(routine.constraints, inputs, backend)

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -242,23 +242,20 @@ def _process_repeated_resources(
 
     # Ensure that routine with repetition only contains resources that we will later overwrite
     child_resources = copy.copy(children[0].resources)
-    # if child_resources_not_in_parent := child_resources.keys() - resources.keys():
-    #     raise BartiqCompilationError(
-    #         """Routine with repetition does not share the same resources as its child."""
-    #         f"""\nFollowing resources are in the child, but not the parent: {child_resources_not_in_parent}"""
-    #     )
-    # if incorrectly_named_resources := [
-    #     x
-    #     for resource in resources.values()
-    #     if (x := backend.serialize(resource.value)) != f"{children[0].name}.{resource.name}"
-    # ]:
-    #     raise BartiqCompilationError(
-    #         """Routine with repetition should have resource names like `child_name.resource_name."""
-    #         f"""\nFound the following incorrectly named resources {incorrectly_named_resources}"""
-    #     )
-    for resource_name, resource in resources.items():
-        assert resource_name in child_resources
-        assert backend.serialize(resource.value) == f"{children[0].name}.{resource.name}"
+    if parent_resources_not_in_child := resources.keys() - child_resources.keys():
+        raise BartiqCompilationError(
+            """Routine with repetition does not share the same resources as its child."""
+            f"""\nFollowing resources are in the parent, but not the child: {parent_resources_not_in_child}"""
+        )
+    if incorrectly_named_resources := [
+        x
+        for resource in resources.values()
+        if (x := backend.serialize(resource.value)) != f"{children[0].name}.{resource.name}"
+    ]:
+        raise BartiqCompilationError(
+            """Routine with repetition should have resource names like `child_name.resource_name."""
+            f"""\nFound the following incorrectly named resources {incorrectly_named_resources}"""
+        )
 
     new_resources = {}
     for resource in child_resources.values():

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -150,8 +150,8 @@ def compile_routine(
             Each dictionary should contain the derived resource's name, type
             and the function mapping a routine to the value of resource.
         skip_verification: flag indicating whether verification of the routine should be skipped.
-        allow_transitive_resources: flag indicating if resource expressions should be compiled only transitively, i.e.
-            the values of the resources will be defined in terms of the child contributions. By default True.
+        compilation_flags: bitwise combination of compilation flags to tailor the compilation process; access these
+            through the `CompilationFlags` object. By default None.
     """
     if not skip_verification and not isinstance(routine, Routine):
         problems = []
@@ -242,20 +242,23 @@ def _process_repeated_resources(
 
     # Ensure that routine with repetition only contains resources that we will later overwrite
     child_resources = copy.copy(children[0].resources)
-    if child_resources_not_in_parent := child_resources.keys() - resources.keys():
-        raise BartiqCompilationError(
-            """Routine with repetition does not share the same resources as its child."""
-            f"""\nFollowing resources are in the child, but not the parent: {child_resources_not_in_parent}"""
-        )
-    if incorrectly_named_resources := [
-        x
-        for resource in resources.values()
-        if (x := backend.serialize(resource.value)) != f"{children[0].name}.{resource.name}"
-    ]:
-        raise BartiqCompilationError(
-            """Routine with repetition should have resource names like `child_name.resource_name."""
-            f"""\nFound the following incorrectly named resources {incorrectly_named_resources}"""
-        )
+    # if child_resources_not_in_parent := child_resources.keys() - resources.keys():
+    #     raise BartiqCompilationError(
+    #         """Routine with repetition does not share the same resources as its child."""
+    #         f"""\nFollowing resources are in the child, but not the parent: {child_resources_not_in_parent}"""
+    #     )
+    # if incorrectly_named_resources := [
+    #     x
+    #     for resource in resources.values()
+    #     if (x := backend.serialize(resource.value)) != f"{children[0].name}.{resource.name}"
+    # ]:
+    #     raise BartiqCompilationError(
+    #         """Routine with repetition should have resource names like `child_name.resource_name."""
+    #         f"""\nFound the following incorrectly named resources {incorrectly_named_resources}"""
+    #     )
+    for resource_name, resource in resources.items():
+        assert resource_name in child_resources
+        assert backend.serialize(resource.value) == f"{children[0].name}.{resource.name}"
 
     new_resources = {}
     for resource in child_resources.values():

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -294,7 +294,7 @@ def _compile(
     inputs: dict[str, TExpr[T]],
     context: Context,
     derived_resources: Iterable[DerivedResources] = (),
-    compilation_flags: CompilationFlags | None = None,
+    compilation_flags: CompilationFlags = CompilationFlags(0),
 ) -> CompiledRoutine[T]:
     try:
         new_constraints = evaluate_constraints(routine.constraints, inputs, backend)

--- a/tests/compilation/test_compile.py
+++ b/tests/compilation/test_compile.py
@@ -30,14 +30,14 @@ COMPILE_TEST_DATA_TRANSITIVE_RESOURCES = load_transitive_resource_data()
 @pytest.mark.parametrize("routine, expected_routine", COMPILE_TEST_DATA)
 def test_compile_with_no_transitive_resources(routine, expected_routine, backend):
     compiled_routine = compile_routine(
-        routine, skip_verification=False, backend=backend, compilation_flags=CompilationFlags.EXPAND_RESOURCES
+        routine, backend=backend, compilation_flags=CompilationFlags.EXPAND_RESOURCES
     ).to_qref()
     assert compiled_routine == expected_routine
 
 
 @pytest.mark.parametrize("routine, compiled_transitive, _", COMPILE_TEST_DATA_TRANSITIVE_RESOURCES)
 def test_compile_with_transitive_resources(routine, compiled_transitive, _, backend):
-    compiled_routine = compile_routine(routine, skip_verification=False, backend=backend).to_qref()
+    compiled_routine = compile_routine(routine, backend=backend).to_qref()
     assert compiled_routine == compiled_transitive
 
 
@@ -140,7 +140,10 @@ COMPILE_ERRORS_TEST_CASES = [
 def test_compile_errors(routine, expected_error, backend):
     with pytest.raises(BartiqCompilationError, match=re.escape(expected_error)):
         compile_routine(
-            routine, preprocessing_stages=[introduce_port_variables], backend=backend, skip_verification=True
+            routine,
+            preprocessing_stages=[introduce_port_variables],
+            backend=backend,
+            compilation_flags=CompilationFlags.SKIP_VERIFICATION,
         )
 
 

--- a/tests/compilation/test_derived_resources.py
+++ b/tests/compilation/test_derived_resources.py
@@ -120,7 +120,7 @@ def test_highwater_of_an_empty_routine_is_zero():
     assert compiled_routine.resources["qubit_highwater"].value == 0
 
 
-@pytest.mark.parametrize("compilation_flags", [None, CompilationFlags.EXPAND_RESOURCES])
+@pytest.mark.parametrize("compilation_flags", [CompilationFlags(0), CompilationFlags.EXPAND_RESOURCES])
 def test_additive_derived_resources_are_processed_correctly(compilation_flags):
     resource_name = "test_resource"
     input_routine = {

--- a/tests/compilation/test_derived_resources.py
+++ b/tests/compilation/test_derived_resources.py
@@ -19,6 +19,7 @@ import yaml
 from qref import SchemaV1
 
 from bartiq import compile_routine
+from bartiq.compilation import CompilationFlags
 from bartiq.compilation.derived_resources import calculate_highwater
 
 
@@ -119,8 +120,8 @@ def test_highwater_of_an_empty_routine_is_zero():
     assert compiled_routine.resources["qubit_highwater"].value == 0
 
 
-@pytest.mark.parametrize("transitive_resources", [True, False])
-def test_additive_derived_resources_are_processed_correctly(transitive_resources):
+@pytest.mark.parametrize("compilation_flags", [None, CompilationFlags.EXPAND_RESOURCES])
+def test_additive_derived_resources_are_processed_correctly(compilation_flags):
     resource_name = "test_resource"
     input_routine = {
         "version": "v1",
@@ -155,12 +156,12 @@ def test_additive_derived_resources_are_processed_correctly(transitive_resources
 
     derived_resources = [{"name": resource_name, "type": "additive", "calculate": add_test_resource}]
     compilation_result = compile_routine(
-        input_routine, derived_resources=derived_resources, allow_transitive_resources=transitive_resources
+        input_routine, derived_resources=derived_resources, compilation_flags=compilation_flags
     )
     compiled_routine = compilation_result.routine
     backend = compilation_result._backend
     assert (
         compiled_routine.resources[resource_name].value == 17
-        if not transitive_resources
+        if CompilationFlags.EXPAND_RESOURCES in compilation_flags
         else backend.as_expression("+".join(f"{child}.{resource_name}" for child in compiled_routine.children))
     )

--- a/tests/compilation/test_postprocessing.py
+++ b/tests/compilation/test_postprocessing.py
@@ -69,7 +69,7 @@ def test_two_postprocessing_stages(backend):
         assert child.type == "cool_kid"
 
 
-@pytest.mark.parametrize("compilation_flags", [None, CompilationFlags.EXPAND_RESOURCES])
+@pytest.mark.parametrize("compilation_flags", [CompilationFlags(0), CompilationFlags.EXPAND_RESOURCES])
 def test_aggregate_resources(backend, compilation_flags):
     routine = _get_simple_routine(backend)
     aggregation_dict = {"a": {"op": 1}, "b": {"op": 2}, "c": {"op": 3}}

--- a/tests/compilation/test_repetitions.py
+++ b/tests/compilation/test_repetitions.py
@@ -357,7 +357,7 @@ def test_error_raised_when_mismatch_between_parent_and_child_resources_and_skipp
     with pytest.raises(
         BartiqCompilationError, match="Routine with repetition does not share the same resources as its child*"
     ):
-        compile_routine(routine, skip_verification=True)
+        compile_routine(routine, compilation_flags=CompilationFlags.SKIP_VERIFICATION)
 
 
 def test_error_raised_when_mismatch_between_parent_and_child_resource_names_and_skipping_verification():
@@ -368,4 +368,4 @@ def test_error_raised_when_mismatch_between_parent_and_child_resource_names_and_
         BartiqCompilationError,
         match="Routine with repetition should have resource names like `child_name.resource_name.*",
     ):
-        compile_routine(routine, skip_verification=True)
+        compile_routine(routine, compilation_flags=CompilationFlags.SKIP_VERIFICATION)

--- a/tests/compilation/test_repetitions.py
+++ b/tests/compilation/test_repetitions.py
@@ -270,7 +270,7 @@ def test_custom_sequence_throws_error_when_replacing_iterator_symbol_on_evaluate
         evaluate(compiled_routine, assignments).routine
 
 
-# At present, the default method of compilation (with transitive resourceSs does not raise an error
+# At present, the default method of compilation (with transitive resources) does not raise an error
 # when attempting to compile a routine where a resource value has the same symbol as an iterator symbol.
 # This is because the resource hierarchy is not compiled fully,
 # and so the parameter map during the compile sequence does not contain child information.


### PR DESCRIPTION
## Description

This PR adds `CompilationFlags`, a `enum.Flag` class that are used to modify the compilation process. 

This replaces the use of the keywords `skip_verification` and `allow_transitive_resources` in `bartiq.compilation._compile.compile`. 
- Instead of `skip_verification=True`, use `compilation_flags = CompilationFlags.SKIP_VERIFICATION`
- Instead of `allow_transitive_resources=False`, use `compilation_flags = CompilationFlags.EXPAND_RESOURCES`.
Flags can be combined bitwise, i.e. `compilation_flags = FLAG1 | FLAG2`.

Other minor updates:
- Fixed a bug where transitive resources were not being evaluated correctly in repetitions. 
- Added `bartiq.compilation` to the docs API reference.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.