### PR TITLE
feat: more performant calculation of derived resources

### DIFF
--- a/src/bartiq/compilation/_common.py
+++ b/src/bartiq/compilation/_common.py
@@ -105,7 +105,8 @@ def evaluate_constraints(
 ) -> Iterable[Constraint[T]]:
     custom_funcs = {} if custom_funcs is None else custom_funcs
     return tuple(
-        _evaluate_constraint(constraint, inputs, backend, custom_funcs)
+        new_constraint
         for constraint in constraints
-        if constraint.status != ConstraintStatus.satisfied
+        if (new_constraint := _evaluate_constraint(constraint, inputs, backend, custom_funcs)).status
+        != ConstraintStatus.satisfied
     )

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -392,7 +392,7 @@ def _compile(
     tmp_routine = (
         compiled_routine
         if CompilationFlags.EXPAND_RESOURCES in compilation_flags
-        else _dummify_child_resources(compiled_routine, backend)
+        else _introduce_placeholder_child_resources(compiled_routine, backend)
     )
     tmp_routine = _add_derived_resources(tmp_routine, backend, derived_resources)
 
@@ -403,7 +403,9 @@ def _accepts_resource_name(func: Calculate[T] | CalculateWithName[T]) -> TypeIs[
     return "resource_name" in inspect.signature(func).parameters
 
 
-def _dummify_resources(compiled_routine: CompiledRoutine[T], backend: SymbolicBackend[T]) -> CompiledRoutine[T]:
+def _introduce_placeholder_resources(
+    compiled_routine: CompiledRoutine[T], backend: SymbolicBackend[T]
+) -> CompiledRoutine[T]:
     return replace(
         compiled_routine,
         resources={
@@ -413,10 +415,15 @@ def _dummify_resources(compiled_routine: CompiledRoutine[T], backend: SymbolicBa
     )
 
 
-def _dummify_child_resources(compiled_routine: CompiledRoutine[T], backend: SymbolicBackend[T]) -> CompiledRoutine[T]:
+def _introduce_placeholder_child_resources(
+    compiled_routine: CompiledRoutine[T], backend: SymbolicBackend[T]
+) -> CompiledRoutine[T]:
     return replace(
         compiled_routine,
-        children={cname: _dummify_resources(child, backend) for cname, child in compiled_routine.children.items()},
+        children={
+            cname: _introduce_placeholder_resources(child, backend)
+            for cname, child in compiled_routine.children.items()
+        },
     )
 
 

--- a/src/bartiq/compilation/_compile.py
+++ b/src/bartiq/compilation/_compile.py
@@ -424,8 +424,8 @@ def _add_derived_resources(
 
 
 def _generate_arithmetic_resources(
-    resources: dict[str, Resource], compiled_children: dict[str, CompiledRoutine[T]], backend: SymbolicBackend[T]
-) -> dict[str, Resource]:
+    resources: dict[str, Resource[T]], compiled_children: dict[str, CompiledRoutine[T]], backend: SymbolicBackend[T]
+) -> dict[str, Resource[T]]:
     """Returns resources dict with sum/prod of all the additive/multiplicative resources of the children.
 
     Since additive/multiplicative resources follow simple rules (value of a resource is equal to sum/product of

--- a/src/bartiq/symbolics/sympy_backend.py
+++ b/src/bartiq/symbolics/sympy_backend.py
@@ -32,7 +32,7 @@ from typing_extensions import TypeAlias
 from ..errors import BartiqCompilationError
 from .ast_parser import parse
 from .backend import ComparisonResult, Number, TExpr
-from .sympy_interpreter import SPECIAL_FUNCS, SympyInterpreter
+from .sympy_interpreter import SPECIAL_FUNCS, Max, SympyInterpreter
 from .sympy_serializer import serialize_expression
 
 NUM_DIGITS_PRECISION = 15
@@ -254,7 +254,7 @@ class SympyBackend:
 
     def max(self, *args):
         """Returns a biggest value from given args."""
-        return sympy.Max(*args)
+        return Max(*set(args))
 
     def sum(self, *args: TExpr[Expr]) -> TExpr[Expr]:
         """Return sum of all args."""

--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -15,11 +15,11 @@ import operator
 from typing import Any
 
 from sympy import (
+    Float,
     Function,
     Heaviside,
     Integer,
     LambertW,
-    Max,
     Min,
     Mod,
     Number,
@@ -57,6 +57,7 @@ from sympy import multiplicity as orig_multiplicity
 from sympy import prod, re, sec, sech, sin, sinh, sqrt, tan, tanh
 from sympy.codegen.cfunctions import exp2, log2, log10
 from sympy.core.numbers import S as sympy_constants
+from sympy.core.sorting import ordered
 
 from .interpreter import Interpreter, debuggable
 
@@ -144,6 +145,23 @@ class nlz(Function):
         if isinstance(n, Integer):
             n = int(n)
             return (n & -n).bit_length() - 1
+
+
+class Max(Function):
+
+    def __new__(cls, *args, **assumptions):
+        args = ordered(set(args))
+        return Function.__new__(cls, *args, **assumptions)
+
+    @classmethod
+    def eval(cls, *args):
+
+        if not args:
+            return sympy_constants.NegativeInfinity
+        elif len(args) == 1:
+            return args[0]
+        elif all(isinstance(n, (Integer, Float)) for n in args):
+            return max(args)
 
 
 SPECIAL_FUNCS = {

--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -148,6 +148,12 @@ class nlz(Function):
 
 
 class Max(Function):
+    """A custom implementation of Max.
+
+    We use a custom Max because for our use cases, Sympy's simplification efforts are usually
+    fruitless. Not doing any advanced simplifications saves us significant amount of time,
+    especially when computing highwater with lots of nested maximums.
+    """
 
     def __new__(cls, *args, **assumptions):
         args = ordered(set(args))

--- a/tests/compilation/data/highwater.yaml
+++ b/tests/compilation/data/highwater.yaml
@@ -135,7 +135,7 @@
         value: 7
       - name: qubit_highwater
         type: qubits
-        value: N + 16
+        value: Max(N, child.qubit_highwater) + 7
       type: null
     version: v1
 # Flat program with multiple children
@@ -319,7 +319,7 @@
       resources:
       - name: qubit_highwater
         type: qubits
-        value: N
+        value: Max(N, A.qubit_highwater, 3 + B.qubit_highwater, N - 3 + C.qubit_highwater, 2 + D.qubit_highwater, N - 2 + E.qubit_highwater)
       type: null
     version: v1
 # Program with an extra hierarchy level
@@ -512,7 +512,7 @@
         resources:
         - name: qubit_highwater
           type: qubits
-          value: N + 3
+          value: Max(N, AA.qubit_highwater, 3 + AB.qubit_highwater, N - 3 + AC.qubit_highwater)
         type: null
       - name: B
         input_params: [N]
@@ -593,7 +593,7 @@
       resources:
       - name: qubit_highwater
         type: qubits
-        value: N + 3
+        value: Max(N, A.qubit_highwater, 3 + B.qubit_highwater, N - 3 + C.qubit_highwater, 2 + D.qubit_highwater, N - 2 + E.qubit_highwater)
       type: null
     version: v1
 # Flat program with disconnected components
@@ -731,7 +731,7 @@
       resources:
       - name: qubit_highwater
         type: qubits
-        value: M + N + 7
+        value: Max(N + M, M + A.qubit_highwater, M + B.qubit_highwater, N + C.qubit_highwater, N + D.qubit_highwater)
       type: null
     version: v1
 # Program with repetitions
@@ -805,10 +805,10 @@
       resources:
       - name: qubit_highwater
         type: qubits
-        value: N + 2
+        value: Max(N, a.qubit_highwater)
       type: null
     version: v1
-# Program with multiple layes & passthroughs
+# Program with multiple layers & passthroughs
 - - program:
       children:
       - name: A
@@ -938,7 +938,7 @@
       resources:
       - name: qubit_highwater
         type: qubits
-        value: 2*M + N + 4
+        value: Max(A.qubit_highwater, 2*M+1 + B.qubit_highwater, 2*M +1 + C.qubit_highwater, D.qubit_highwater)
       type: null
     version: v1
 # Flat program with two (connected) strains
@@ -1101,6 +1101,6 @@
       resources:
       - name: qubit_highwater
         type: qubits
-        value: N + 7
+        value: Max(N, S.qubit_highwater, N/2 + A.qubit_highwater, N/2 + B.qubit_highwater, N/2 + C.qubit_highwater, N/2 + D.qubit_highwater)
       type: null
     version: v1

--- a/tests/compilation/test_derived_resources.py
+++ b/tests/compilation/test_derived_resources.py
@@ -18,7 +18,7 @@ import pytest
 import yaml
 from qref import SchemaV1
 
-from bartiq import compile_routine
+from bartiq import CompiledRoutine, compile_routine
 from bartiq.compilation import CompilationFlags
 from bartiq.compilation.derived_resources import calculate_highwater
 
@@ -38,8 +38,8 @@ HIGHWATER_TEST_DATA = load_highwater_test_data()
 @pytest.mark.parametrize("routine, expected_routine", HIGHWATER_TEST_DATA)
 def test_compute_highwater(routine, expected_routine, backend):
     derived_resources = [{"name": "qubit_highwater", "type": "qubits", "calculate": calculate_highwater}]
-    compiled_routine = compile_routine(routine, derived_resources=derived_resources, backend=backend)
-    assert compiled_routine.to_qref() == expected_routine
+    compiled_routine = compile_routine(routine, derived_resources=derived_resources, backend=backend).routine
+    assert compiled_routine == CompiledRoutine.from_qref(expected_routine, backend)
 
 
 def test_compute_highwater_with_custom_names(backend):

--- a/tests/symbolics/test_sympy_backend.py
+++ b/tests/symbolics/test_sympy_backend.py
@@ -12,12 +12,12 @@ Tests for the SympyExpression implementation.
 
 import pytest
 from sympy import E
-from sympy import Max as sympy_max
 from sympy import Min as sympy_min
 from sympy import cos, exp, pi, sin, sqrt, symbols, sympify
 
 from bartiq.errors import BartiqCompilationError
 from bartiq.symbolics import sympy_backend
+from bartiq.symbolics.sympy_interpreter import Max
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_min_max_works_for_numerical_values(backend):
 def test_min_max_works_for_symbols(backend):
     values = symbols("a, b, c")
     assert backend.min(*values) == sympy_min(*values)
-    assert backend.max(*values) == sympy_max(*values)
+    assert backend.max(*values) == Max(*values)
 
 
 @pytest.mark.parametrize(

--- a/tests/symbolics/test_sympy_interpreter.py
+++ b/tests/symbolics/test_sympy_interpreter.py
@@ -18,7 +18,6 @@ from sympy import (
     Function,
     Heaviside,
     LambertW,
-    Max,
     Min,
     Mod,
     Product,
@@ -65,7 +64,7 @@ from sympy.codegen.cfunctions import exp2, log2, log10
 from sympy.core.numbers import S as sympy_constants
 
 from bartiq.symbolics.sympy_backend import parse_to_sympy
-from bartiq.symbolics.sympy_interpreter import SPECIAL_PARAMS, Round, multiplicity
+from bartiq.symbolics.sympy_interpreter import SPECIAL_PARAMS, Max, Round, multiplicity
 from bartiq.symbolics.sympy_serializer import serialize_expression
 
 


### PR DESCRIPTION
## Description

This PR introduced performance improvements for calculating derived resources, as well as specific improvements to the qubit highwater calculation.

So far, the process of calculating derived resources wasn't respecting the compilation flags. Therefore, even if other resources weren't being expanded for usual resources, they were being expanded for the purpose of computing the derived ones. This was undermining our previous optimization efforts, as the highwater (which is a derived resource) calculation is currently the biggest bottleneck. This PR solves this problem by temporarily replacing child resources with dummy variables, unless EXPAND_RESOURCES flag is passed. Such "dummified" routine is passed to the resource-computing functions, which can access resource values per usual - which makes this change fully backwards compatible.

Additionally, profiling the double factorization example (the new one, not the one in one of our test yamls), revealed that a lot of time is spend spinning wheels in the `sympy.Max` function. This is because sympy makes a significant effort trying to simplify `Max` but is ultimately unable to. This is unsurprising, given the complexity of the expressions occuring in port sizes and the fact that we don't have assumptions system. Therefore, I replaced the default `Max` with a custom one, which puts significantly less effort simplifying itself.

As a result of both the described changes, there is a following improvement in running new DF example (this is a representable result, not an average, but the results don't vary that much between runs):

**Before changes**:

- Compilation time:  137.3914284160128s
- Evaluation_time:  482.83837754197884s

**After changes**:

- Compilation time:  4.762517333030701s
- Evaluation_time:  2.800215625029523s


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.