### PR TITLE
fix: avoid SymPy ``LatexPrinter`` modifiers to change subscripted parameter symbols

### DIFF
--- a/src/bartiq/integrations/latex.py
+++ b/src/bartiq/integrations/latex.py
@@ -24,6 +24,7 @@ from qref.schema_v1 import (
     SchemaV1,
 )
 from sympy import latex, symbols
+from sympy.printing.latex import modifier_dict as sympy_latex_modifier_dict
 
 from ..symbolics.sympy_backend import parse_to_sympy
 
@@ -200,6 +201,13 @@ def _format_param_math_with_subscript(param: str) -> str:
     symbol, subscript = param.split("_", 1)
     subscript = subscript.replace("_", r"\_")
     subscript_latex = latex(symbols(subscript))
+
+    # Check if any modifier would be applied when using SymPy's default Latex
+    # printing - if so, enclose the symbol with curly braces to create a Latex
+    # grouping and avoid unwanted modifications (e.g., "local" would become
+    # "\mathcal{lo}" just because the string ends with the "cal" modifier)
+    if any(symbol.endswith(modifier) for modifier in list(sympy_latex_modifier_dict.keys())):
+        symbol = "{" + symbol + "}"
     symbol_latex = latex(symbols(symbol))
 
     # If subscript contains something that needs LaTeX to render, use that, but render text as text.

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -323,6 +323,23 @@ LATEX_TEST_CASES = [
 &\text{out\_0} = None
 """,
     ),
+    # Latex printer modification case
+    (
+        RoutineV1(
+            name="my_routine",
+            type=None,
+            resources=[
+                {"name": "local_highwater", "type": "other", "value": "10"},
+            ],
+            ),
+        {},
+
+        r"""
+&\text{RoutineV1 \textrm{(my\_routine)}}\newline
+&\underline{\text{Resources:}}\\
+&{local}_{\text{highwater}} = 10
+""",
+    ),
 ]
 
 

--- a/tests/integrations/test_latex.py
+++ b/tests/integrations/test_latex.py
@@ -331,9 +331,8 @@ LATEX_TEST_CASES = [
             resources=[
                 {"name": "local_highwater", "type": "other", "value": "10"},
             ],
-            ),
+        ),
         {},
-
         r"""
 &\text{RoutineV1 \textrm{(my\_routine)}}\newline
 &\underline{\text{Resources:}}\\


### PR DESCRIPTION
## Description

This PR is meant to close https://github.com/PsiQ/bartiq/issues/163.

**Context**

The rendering issue arises when calling the ``symbols`` SymPy function, which under the hood attempts to create SymPy ``Symbol`` objects and then, once done, prints them.

![image](https://github.com/user-attachments/assets/ba46a5ed-5301-4f1b-b065-5783c1765aa9)

A ``Symbol`` object in SymPy is also a ``Printable`` object, whose [``_repr_latex_`` method](https://github.com/sympy/sympy/blob/da6d1f3cb324ad0bf74d123d85c390029be997ce/sympy/core/_print_helpers.py#L54) is being called in a Jupyter environment. However, this method defaults to a behaviour that interprets certain input suffixes as default modifiers. The example string from #163 had the specific `cal` suffix, which happens to be one of the modifiers ([see here](https://github.com/sympy/sympy/blob/da6d1f3cb324ad0bf74d123d85c390029be997ce/sympy/printing/latex.py#L89) for the modifier dictionary that is being used in the ``LatexPrinter`` class).


**Implemented solution**

The implemented solution does the following:

* In case we have a subscript expression (such as in issue #163), we check if the input string ends in either of the modifiers from SymPy's modifier dictionary;
* If the input string indeed ends in such a modifier, then we enclose the string with curly brackets such that it is made into a LaTeX grouping expression, effectively avoiding SymPy's logic as well as preserving the expected Latex rendering.

*Note:* no dependencies were added in the solution.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have included test cases validating introduced feature/fix.
*Note*: At the moment, a single test case was added. I'm happy to include more testing if that helps further this bug fix. :ok_hand: 
- [ ] I have updated documentation.
*Note*: Having checked the documentation, as `routine_to_latex` is not explicitly mentioned in the docs, no changes were made. Having said that, I'm happy to include any relevant updates, if that helps. :+1: 