### PR TITLE
feat(transform): add add_circuit_volume feature, tests, and notebook docs

### DIFF
--- a/docs/tutorials/01_basic_example.ipynb
+++ b/docs/tutorials/01_basic_example.ipynb
@@ -708,6 +708,46 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b9394ebb",
+   "metadata": {},
+   "source": [
+    "Now that we have evaluated our routine, we can automatically add a `circuit_volume` resource. This requires that both `aggregated_t_gates` and `qubit_highwater` resources are present. If your routine uses `T_gates`, you can set `aggregated_t_gates` to `T_gates` for this purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d81a2f09",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Circuit volume: 3665\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bartiq import Resource, ResourceType\n",
+    "from bartiq.transform import add_circuit_volume\n",
+    "\n",
+    "# Set aggregated_t_gates if needed\n",
+    "evaluated_routine.resources[\"aggregated_t_gates\"] = evaluated_routine.resources[\"T_gates\"]\n",
+    "# Set qubit_highwater (example value)\n",
+    "evaluated_routine.resources[\"qubit_highwater\"] = Resource(\n",
+    "    name=\"qubit_highwater\",\n",
+    "    type=ResourceType.other,\n",
+    "    value=5,\n",
+    ")\n",
+    "\n",
+    "# Add circuit_volume\n",
+    "routine_with_volume = add_circuit_volume(evaluated_routine)\n",
+    "print(\"Circuit volume:\", routine_with_volume.resources[\"circuit_volume\"].value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c892d377-fc47-4796-bc0a-fcc28133b8c9",
    "metadata": {},
    "source": [

--- a/src/bartiq/transform.py
+++ b/src/bartiq/transform.py
@@ -121,8 +121,7 @@ def add_circuit_volume(
         CompiledRoutine with the 'circuit_volume' resource added.
     """
     new_children = {
-        name: add_circuit_volume(child, name_of_aggregated_t, backend)
-        for name, child in routine.children.items()
+        name: add_circuit_volume(child, name_of_aggregated_t, backend) for name, child in routine.children.items()
     }
 
     resources = dict(routine.resources)
@@ -136,6 +135,7 @@ def add_circuit_volume(
         )
 
     return replace(routine, resources=resources, children=new_children)
+
 
 def _add_aggregated_resources_to_subroutine(
     subroutine: CompiledRoutine[T],

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -16,7 +16,7 @@ import pytest
 import sympy
 from qref.schema_v1 import RoutineV1
 
-from bartiq import Routine
+from bartiq import Routine, Resource, ResourceType
 from bartiq.transform import add_aggregated_resources
 
 ccry_gate = {
@@ -225,8 +225,6 @@ def _compare_routines(routine, expected):
         _compare_routines(routine.children[child], expected.children[child])
 
 
-from bartiq.transform import add_circuit_volume
-from bartiq import CompiledRoutine, Resource, ResourceType
 
 @pytest.mark.parametrize(
     "resources,expected_volume,should_exist",

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -225,7 +225,6 @@ def _compare_routines(routine, expected):
         _compare_routines(routine.children[child], expected.children[child])
 
 
-
 @pytest.mark.parametrize(
     "resources,expected_volume,should_exist",
     [

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 import pytest
 import sympy
 from qref.schema_v1 import RoutineV1
@@ -225,75 +227,133 @@ def _compare_routines(routine, expected):
         _compare_routines(routine.children[child], expected.children[child])
 
 
+def _assert_circuit_volume_by_index(
+    routine,
+    expected_volumes,
+    should_exist,
+    name_of_circuit_volume="circuit_volume",
+    name_of_qubit_highwater="qubit_highwater",
+):
+    """
+    Checks circuit_volume for parent and children by index in expected_volumes.
+    expected_volumes: [parent, child1, child2, ...]
+    """
+    nodes = [routine] + list(routine.children.values())
+    for idx, node in enumerate(nodes):
+        expected_volume = expected_volumes[idx]
+        if should_exist and expected_volume is not None:
+            assert name_of_circuit_volume in node.resources
+            # Use the parameterized name for qubit_highwater
+            assert name_of_qubit_highwater in node.resources
+            assert sympy.simplify(node.resources[name_of_circuit_volume].value - sympy.sympify(expected_volume)) == 0
+        else:
+            assert name_of_circuit_volume not in node.resources
+
+
 @pytest.mark.parametrize(
-    "resources,expected_volume,should_exist",
+    "parent_resources,children_resources,expected_volumes,should_exist,custom_t,custom_qh",
     [
-        # Correct case: aggregated_t_gates and qubit_highwater present
+        # Custom resource names, all present
         (
-            {
-                "aggregated_t_gates": Resource("aggregated_t_gates", ResourceType.additive, 10),
-                "qubit_highwater": Resource("qubit_highwater", ResourceType.other, 5),
-            },
-            50,
+            {"my_t": Resource("my_t", ResourceType.additive, 7), "my_qh": Resource("my_qh", ResourceType.other, 3)},
+            [
+                {"my_t": Resource("my_t", ResourceType.additive, 2), "my_qh": Resource("my_qh", ResourceType.other, 5)},
+            ],
+            [21, 10],
             True,
+            "my_t",
+            "my_qh",
         ),
-        # Symbolic case
+        # Custom resource names, child missing qubit highwater
         (
-            {
-                "aggregated_t_gates": Resource("aggregated_t_gates", ResourceType.additive, "n"),
-                "qubit_highwater": Resource("qubit_highwater", ResourceType.other, "m"),
-            },
-            "n*m",
+            {"my_t": Resource("my_t", ResourceType.additive, 7), "my_qh": Resource("my_qh", ResourceType.other, 3)},
+            [
+                {"my_t": Resource("my_t", ResourceType.additive, 2)},
+            ],
+            [21, None],
             True,
+            "my_t",
+            "my_qh",
         ),
-        # Missing qubit_highwater
+        # Custom resource names, parent missing qubit highwater
+        ({"my_t": Resource("my_t", ResourceType.additive, 7)}, [], [None], False, "my_t", "my_qh"),
+        # Deeply nested children, all present
         (
-            {
-                "aggregated_t_gates": Resource("aggregated_t_gates", ResourceType.additive, 10),
-                # "qubit_highwater" missing
-            },
-            None,
-            False,
-        ),
-        # Missing aggregated_t_gates
-        (
-            {
-                "qubit_highwater": Resource("qubit_highwater", ResourceType.other, 5),
-                # "aggregated_t_gates" missing
-            },
-            None,
-            False,
-        ),
-        # Both present, but with float
-        (
-            {
-                "aggregated_t_gates": Resource("aggregated_t_gates", ResourceType.additive, 2.5),
-                "qubit_highwater": Resource("qubit_highwater", ResourceType.other, 4),
-            },
-            10.0,
+            {"agg": Resource("agg", ResourceType.additive, 2), "qhw": Resource("qhw", ResourceType.other, 4)},
+            [
+                {"agg": Resource("agg", ResourceType.additive, 3), "qhw": Resource("qhw", ResourceType.other, 5)},
+                {"agg": Resource("agg", ResourceType.additive, 1), "qhw": Resource("qhw", ResourceType.other, 2)},
+            ],
+            [8, 15, 2],
             True,
+            "agg",
+            "qhw",
         ),
     ],
 )
-def test_add_circuit_volume_strict(resources, expected_volume, should_exist, backend):
+def test_add_circuit_volume_custom_names_and_children(
+    parent_resources, children_resources, expected_volumes, should_exist, custom_t, custom_qh, backend
+):
     from bartiq import CompiledRoutine
     from bartiq.transform import add_circuit_volume
 
-    routine = CompiledRoutine(
-        name="test",
+    children = {}
+    for i, res in enumerate(children_resources):
+        children[f"child{i + 1}"] = CompiledRoutine(
+            name=f"child{i + 1}",
+            type=None,
+            input_params=(),
+            children={},
+            ports={},
+            resources=res,
+            constraints=(),
+            connections={},
+            repetition=None,
+            children_order=(),
+        )
+    parent = CompiledRoutine(
+        name="parent",
+        type=None,
+        input_params=(),
+        children=children,
+        ports={},
+        resources=parent_resources,
+        constraints=(),
+        connections={},
+        repetition=None,
+        children_order=tuple(children.keys()),
+    )
+
+    result = add_circuit_volume(
+        parent, name_of_aggregated_t=custom_t, name_of_qubit_highwater=custom_qh, backend=backend
+    )
+    _assert_circuit_volume_by_index(
+        result,
+        expected_volumes,
+        should_exist,
+        name_of_circuit_volume="circuit_volume",
+        name_of_qubit_highwater=custom_qh,
+    )
+
+
+def test_add_circuit_volume_warns_on_missing_resources(backend):
+    from bartiq import CompiledRoutine
+    from bartiq.transform import add_circuit_volume
+
+    parent_resources = {"agg": Resource("agg", ResourceType.additive, 2)}
+    parent = CompiledRoutine(
+        name="parent",
         type=None,
         input_params=(),
         children={},
         ports={},
-        resources=resources,
+        resources=parent_resources,
         constraints=(),
         connections={},
         repetition=None,
         children_order=(),
     )
-    result = add_circuit_volume(routine, backend=backend)
-    if should_exist:
-        assert "circuit_volume" in result.resources
-        assert sympy.simplify(result.resources["circuit_volume"].value - sympy.sympify(expected_volume)) == 0
-    else:
-        assert "circuit_volume" not in result.resources
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = add_circuit_volume(parent, name_of_aggregated_t="agg", name_of_qubit_highwater="qhw", backend=backend)
+        assert any("Missing required resources" in str(warn.message) for warn in w)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -16,7 +16,7 @@ import pytest
 import sympy
 from qref.schema_v1 import RoutineV1
 
-from bartiq import Routine, Resource, ResourceType
+from bartiq import Resource, ResourceType, Routine
 from bartiq.transform import add_aggregated_resources
 
 ccry_gate = {
@@ -276,8 +276,8 @@ def _compare_routines(routine, expected):
     ],
 )
 def test_add_circuit_volume_strict(resources, expected_volume, should_exist, backend):
-    from bartiq.transform import add_circuit_volume
     from bartiq import CompiledRoutine
+    from bartiq.transform import add_circuit_volume
 
     routine = CompiledRoutine(
         name="test",


### PR DESCRIPTION
## Description

this pr aim to close #150

This PR introduces the ``add_circuit_volume`` utility to the transform module. Circuit volume is a useful composite metric in quantum resource estimation, defined as the product of the total T-gate count (after aggregation) and the qubit high-water mark. This feature is needed to enable users to easily and automatically add a ``circuit_volume`` resource to their routines, which is commonly used for benchmarking and hardware feasibility analysis.

Implemented Solution:

Added the ``add_circuit_volume`` function to transform.py. This function traverses a compiled routine and adds a ``circuit_volume`` resource to each subroutine where both ``aggregated_t_gates`` and ``qubit_highwater`` are present.
The function strictly uses ``aggregated_t_gates`` as the T-gate resource, following the original design intent. No fallback to ``T_gates`` is performed, ensuring users explicitly aggregate resources if needed.
Comprehensive test cases were added to test_transform.py to validate the feature, including numeric, symbolic, and missing-resource scenarios.
Documentation tutorial notebook were updated to demonstrate usage and clarify the requirements for using ``add_circuit_volume``.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.