### PR TITLE
feat(transform): add add_circuit_volume function to compute circuit v…

### DIFF
--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -17,7 +17,7 @@ import sympy
 from qref.schema_v1 import RoutineV1
 
 from bartiq import Routine
-from bartiq.transform import add_aggregated_resources
+from bartiq.transform import add_aggregated_resources, add_circuit_volume
 
 ccry_gate = {
     "name": "ccry_gate",
@@ -223,3 +223,24 @@ def _compare_routines(routine, expected):
 
     for child in routine.children:
         _compare_routines(routine.children[child], expected.children[child])
+
+
+def test_add_circuit_volume_simple(backend):
+    from bartiq import CompiledRoutine, Resource, ResourceType
+    # Create a simple routine with required resources
+    routine = CompiledRoutine(
+        name="test",
+        type=None,
+        input_params=[],
+        children={},
+        ports={},
+        resources={
+            "aggregated_t_gates": Resource("aggregated_t_gates", ResourceType.additive, 5),
+            "qubit_highwater": Resource("qubit_highwater", ResourceType.qubits, 3),
+        },
+        connections={},
+        children_order=(),
+    )
+    out = add_circuit_volume(routine, backend=backend)
+    assert "circuit_volume" in out.resources
+    assert backend.value_of(out.resources["circuit_volume"].value) == 15


### PR DESCRIPTION
## Summary

This PR implements the feature request from issue #150 by adding a new function, `add_circuit_volume`, to the `transform` module. The function recursively adds a `circuit_volume` resource to each subroutine in a `CompiledRoutine`, calculated as the product of `aggregated_t_gates` and `qubit_highwater` resources.

## Details

- **Functionality:**  
  - Adds `add_circuit_volume` to `src/bartiq/transform.py`.
  - The function traverses all subroutines and, if both `aggregated_t_gates` and `qubit_highwater` are present, adds a new `circuit_volume` resource as their product.
  - Uses the symbolic backend for compatibility with symbolic and numeric values.

- **Testing:**  
  - Adds a direct test in `tests/test_transform.py` to verify that `circuit_volume` is correctly added and computed.

Closes #150
## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.