### PR TITLE
refactor bartiq to use single symbol for expressing pow method

### DIFF
--- a/src/bartiq/symbolics/ast_parser.py
+++ b/src/bartiq/symbolics/ast_parser.py
@@ -161,7 +161,7 @@ def _replace_xor_op(expression: str) -> str:
 
 
 # Preprocessing stage replacing ^ with ** for exponentiation
-_XOR_REPLACEMENT = _PreprocessingStage(matches=_contains_xor_op, preprocess=_replace_xor_op)
+_XOR_OP_REPLACEMENT = _PreprocessingStage(matches=_contains_xor_op, preprocess=_replace_xor_op)
 
 
 # Sequence of all known preprocessing stages.
@@ -173,7 +173,7 @@ _PREPROCESSING_STAGES = (
     _PORT_REPLACEMENT,
     _LAMBDA_REPLACEMENT,
     _IN_REPLACEMENT,
-    _XOR_REPLACEMENT,
+    _XOR_OP_REPLACEMENT,
 )
 
 

--- a/src/bartiq/symbolics/ast_parser.py
+++ b/src/bartiq/symbolics/ast_parser.py
@@ -150,6 +150,20 @@ def _replace_in(expression: str) -> str:
 # Preprocessing stage replacing "in"s with _in
 _IN_REPLACEMENT = _PreprocessingStage(matches=_contains_in, preprocess=_replace_in)
 
+
+def _contains_xor_op(expression: str) -> bool:
+    return "^" in expression
+
+
+def _replace_xor_op(expression: str) -> str:
+    warn("Using ^ operator to denote exponentiation is deprecated.", DeprecationWarning)
+    return expression.replace("^", "**")
+
+
+# Preprocessing stage replacing ^ with ** for exponentiation
+_XOR_REPLACEMENT = _PreprocessingStage(matches=_contains_xor_op, preprocess=_replace_xor_op)
+
+
 # Sequence of all known preprocessing stages.
 # If there are any new preprocessing stages, they should be added here.
 # Note that this list is not exposed/configurable by the user, because it wouldn't really make sens -
@@ -159,6 +173,7 @@ _PREPROCESSING_STAGES = (
     _PORT_REPLACEMENT,
     _LAMBDA_REPLACEMENT,
     _IN_REPLACEMENT,
+    _XOR_REPLACEMENT,
 )
 
 

--- a/src/bartiq/symbolics/ast_parser.py
+++ b/src/bartiq/symbolics/ast_parser.py
@@ -60,7 +60,6 @@ _BINARY_OP_MAP = {
     ast.Sub: operator.sub,
     ast.Mod: operator.mod,
     ast.Pow: operator.pow,
-    ast.BitXor: operator.pow,
     ast.FloorDiv: operator.floordiv,
 }
 
@@ -140,19 +139,6 @@ def _replace_lambda(expression: str) -> str:
 _LAMBDA_REPLACEMENT = _PreprocessingStage(matches=_contains_lambda, preprocess=_replace_lambda)
 
 
-def _contains_xor_op(expression: str) -> bool:
-    return "^" in expression
-
-
-def _replace_xor_op(expression: str) -> str:
-    warn("Using ^ operator to denote exponentiation is deprecated. Use ** operator instead.", DeprecationWarning)
-    return expression.replace("^", "**")
-
-
-# Preprocessing stage replacing xor operators (^) with power (**) operators.
-_XOR_OP_REPLACEMENT = _PreprocessingStage(matches=_contains_xor_op, preprocess=_replace_xor_op)
-
-
 def _contains_in(expression: str) -> bool:
     return re.search(_IN_PATTERN, expression) is not None
 
@@ -172,7 +158,6 @@ _PREPROCESSING_STAGES = (
     _WILDCARD_REPLACEMENT,
     _PORT_REPLACEMENT,
     _LAMBDA_REPLACEMENT,
-    _XOR_OP_REPLACEMENT,
     _IN_REPLACEMENT,
 )
 

--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -69,7 +69,6 @@ BINARY_OPS = {
     "*": operator.mul,
     "/": operator.truediv,
     "//": operator.floordiv,
-    "^": operator.pow,
     "**": operator.pow,
     "%": operator.mod,
 }

--- a/src/bartiq/symbolics/sympy_serializer.py
+++ b/src/bartiq/symbolics/sympy_serializer.py
@@ -44,7 +44,7 @@ class BartiqPrinter(StrPrinter):
         base, exponent = expr.args
         base_str = self._print(self.parenthesize(expr.base, PREC))
         exp_str = self._print(self.parenthesize(expr.exp, PREC))
-        return f"{base_str} ^ {exp_str}"
+        return f"{base_str} ** {exp_str}"
 
 
 def serialize_expression(expr: Expr) -> str:

--- a/tests/compilation/test_compile.py
+++ b/tests/compilation/test_compile.py
@@ -238,7 +238,7 @@ N_CHILDREN = 1000
 @pytest.mark.parametrize(
     "compilation_flags, expected_t_count, expected_foo",
     [
-        [CompilationFlags.EXPAND_RESOURCES, f"{N_CHILDREN}*n", f"n ^ {N_CHILDREN}"],
+        [CompilationFlags.EXPAND_RESOURCES, f"{N_CHILDREN}*n", f"n ** {N_CHILDREN}"],
         [
             None,
             " + ".join(sorted(f"child_{x}.t_count" for x in range(N_CHILDREN))),

--- a/tests/symbolics/test_sympy_interpreter.py
+++ b/tests/symbolics/test_sympy_interpreter.py
@@ -176,7 +176,7 @@ def make_alphabet_test_case(letter, use):
 
 def make_string_expression(x):
     """Create an expression string that contains all the possible operators."""
-    return f"{x} + {x} * {x} - {x} / {x} ^ {x} % {x}"
+    return f"{x} + {x} * {x} - {x} / {x} ** {x} % {x}"
 
 
 def make_sympy_expression(x):
@@ -241,18 +241,18 @@ PARSE_TEST_CASES = [
     ("2 * 3.14159", 6.28318),
     ("3.141 * 3.141 / 10", Float(0.9865881)),
     ("PI * PI / 10", Pi * Pi / 10),
-    ("PI ^ 2", Pi**2),
-    ("round(PI ^ 2)", 10),
+    ("PI ** 2", Pi**2),
+    ("round(PI ** 2)", 10),
     ("6.02E23 * 8.048", 4.844896e24),
     ("sin(PI / 2)", 1),
-    ("10 + sin(PI / 4) ^ 2", Rational(21, 2)),
+    ("10 + sin(PI / 4) ** 2", Rational(21, 2)),
     ("exp(0)", 1),
     ("exp(1)", E),
-    ("2 ^ 3 ^ 2", 512),
-    ("(2 ^ 3) ^ 2", 64),
-    ("2 ^ 3 + 2", 10),
-    ("2 ^ 3 + 5", 13),
-    ("2 ^ 9", 512),
+    ("2 ** 3 ** 2", 512),
+    ("(2 ** 3) ** 2", 64),
+    ("2 ** 3 + 2", 10),
+    ("2 ** 3 + 5", 13),
+    ("2 ** 9", 512),
     ("sgn(-2)", -1),
     ("sgn(0)", 0),
     ("sgn(0.1)", 1),
@@ -273,8 +273,8 @@ PARSE_TEST_CASES = [
     ("sum()", 0),
     ("sum(-1, 42, 0)", 41),
     ("sum(-1, 42, x)", 41 + x),
-    ("sum_over(x^2, x, 1, y)", Sum(x**2, (x, 1, y))),
-    ("prod_over(x^2, x, 1, y)", Product(x**2, (x, 1, y))),
+    ("sum_over(x**2, x, 1, y)", Sum(x**2, (x, 1, y))),
+    ("prod_over(x**2, x, 1, y)", Product(x**2, (x, 1, y))),
     ("round(1.49999999)", 1),
     ("round(1.50000001)", 2),
     ("round(x)", Round(x)),
@@ -351,7 +351,7 @@ PARSE_TEST_CASES = [
     ("x * y * z", x * y * z),
     ("x / y / z", (x / y) / z),
     ("x // y // z", (x // y) // z),
-    ("x ^ y ^ z", x ** (y**z)),
+    ("x ** y ** z", x ** (y**z)),
     ("x + y - z", ((x + y) - z)),
     ("x * y / z", ((x * y) / z)),
     ("x / y * z", ((x / y) * z)),
@@ -359,7 +359,7 @@ PARSE_TEST_CASES = [
     ("x // y * z", ((x // y) * z)),
     # Pathological cases
     ("x / y // z", (x / y) // z),
-    ("x ^ y ** z", x ** (y**z)),
+    ("x ** y ** z", x ** (y**z)),
     # Special functions
     ("multiplicity(x, y)", multiplicity(x, y)),
     ("multiplicity(x, 2)", multiplicity(x, 2)),

--- a/tests/symbolics/test_sympy_serializer.py
+++ b/tests/symbolics/test_sympy_serializer.py
@@ -27,7 +27,7 @@ E = sympy_constants.Exp1
     "expression, expected_string",
     [
         # Exponentiation
-        (x ** (y**z), "x ^ (y ^ z)"),
+        (x ** (y**z), "x ** (y ** z)"),
         # Exponential
         (E, "exp(1)"),
         # Pi
@@ -35,13 +35,13 @@ E = sympy_constants.Exp1
         # Modulo
         (x % y, "Mod(x, y)"),
         # Summation series
-        (Sum(x**2, (x, 1, y)), "sum_over(x ^ 2, x, 1, y)"),
+        (Sum(x**2, (x, 1, y)), "sum_over(x ** 2, x, 1, y)"),
         # Product series
-        (Product(x**2, (x, 1, y)), "prod_over(x ^ 2, x, 1, y)"),
+        (Product(x**2, (x, 1, y)), "prod_over(x ** 2, x, 1, y)"),
         # All together now
         (
             Product(Sum(x ** (y**z) + x % y, (x, 1, E)), (y, 1, Pi)),
-            "prod_over(sum_over(x ^ (y ^ z) + Mod(x, y), x, 1, exp(1)), y, 1, PI)",
+            "prod_over(sum_over(x ** (y ** z) + Mod(x, y), x, 1, exp(1)), y, 1, PI)",
         ),
     ],
 )


### PR DESCRIPTION
## Description

Currently in Bartiq we allow to express pow function as both ^ and **.
This is problematic since:

^ in Python is a XOR operator,
an expression including one symbol could be later serialized and the symbol might turn into a different one, which could be confusing.
Refactored code to use ** instead of ^

Closes #138 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation. (could not find instances using ^)

