### PR TITLE
fix: make custom max correctly evaluate when numeric arguments are rationals

### DIFF
--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -25,6 +25,7 @@ from sympy import (
     Mod,
     Number,
     Product,
+    Rational,
     Sum,
     Symbol,
     acos,
@@ -198,7 +199,7 @@ class Max(Function):
             return sympy_constants.NegativeInfinity
         elif len(args) == 1:
             return args[0]
-        elif all(isinstance(n, (Integer, Float)) for n in args):
+        elif all(isinstance(n, (Integer, Float, Rational)) for n in args):
             return max(args)
 
 

--- a/tests/symbolics/test_sympy_interpreter.py
+++ b/tests/symbolics/test_sympy_interpreter.py
@@ -58,6 +58,7 @@ from sympy import (
     sin,
     sinh,
     sqrt,
+    sympify,
     tan,
     tanh,
 )
@@ -435,3 +436,16 @@ def test_ntz_parametrized(value, expected, raises, match):
             ntz(value)
     else:
         assert ntz(value) == expected
+
+
+@pytest.mark.parametrize(
+    "args, expected_max",
+    [
+        ([sympify("2/3"), 0.5], sympify("2/3")),
+        ([sympify(3) / 2, 2], 2),
+        ([4 / sympify(5), 0], 4 / sympify(5)),
+        ([sympify("1/5"), sympify("6/7"), sympify("10/7")], sympify("10/7")),
+    ],
+)
+def test_custom_max_evaluates_if_some_inputs_are_rationals(args, expected_max):
+    assert Max(*args) == expected_max


### PR DESCRIPTION
## Description

As reported by @seangreenaway , our custom `Max` function fails to evaluate for numerical arguments if at least one of them is of rational type. This PR fixes it adds relevant tests.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.