### PR TITLE
fix: make ntz(0) = -1

### DIFF
--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -163,8 +163,6 @@ class ntz(Function):
             n = int(n)
             if n < 0:
                 raise ValueError(f"ntz requires non-negative integer; found {n}")
-            if n == 0:
-                return 0
             return (n & -n).bit_length() - 1
 
 

--- a/src/bartiq/symbolics/sympy_interpreter.py
+++ b/src/bartiq/symbolics/sympy_interpreter.py
@@ -147,11 +147,12 @@ class multiplicity(Function):
 class ntz(Function):
     @classmethod
     def eval(cls, n):
-        """
-        Returns the number of trailing zeros in the binary representation of n.
+        """Returns the number of trailing zeros in the binary representation of n.
+
         Only defined for non-negative integers.
-        Returns 0 for input 0.
+        For n = 0 returns -1.
         For symbolic input, returns unevaluated ntz(n).
+
         Raises:
             TypeError: If input is not an integer (when numeric).
             ValueError: If input is a negative integer.

--- a/tests/symbolics/test_sympy_interpreter.py
+++ b/tests/symbolics/test_sympy_interpreter.py
@@ -409,33 +409,56 @@ def test_sympy_interpreter_raises_on_xor_operator():
 
 
 @pytest.mark.parametrize(
-    "value,expected,raises,match",
+    "value,expected",
     [
-        (0, 0, None, None),
-        (1, 0, None, None),
-        (2, 1, None, None),
-        (4, 2, None, None),
-        (8, 3, None, None),
-        (16, 4, None, None),
-        (Integer(0), 0, None, None),
-        (Integer(1), 0, None, None),
-        (Integer(2), 1, None, None),
-        (Integer(4), 2, None, None),
-        (Integer(8), 3, None, None),
-        (Integer(16), 4, None, None),
-        (1.5, None, TypeError, r"ntz requires integer argument; found 1\.5+"),
-        (10.0, None, TypeError, r"ntz requires integer argument; found 10\.0+"),
-        (Symbol("x"), ntz(Symbol("x")), None, None),
-        (-1, None, ValueError, "ntz requires non-negative integer; found -1"),
-        (Integer(-5), None, ValueError, "ntz requires non-negative integer; found -5"),
+        (0, -1),
+        (1, 0),
+        (2, 1),
+        (4, 2),
+        (8, 3),
+        (16, 4),
+        (Integer(0), -1),
+        (Integer(1), 0),
+        (Integer(2), 1),
+        (Integer(4), 2),
+        (Integer(8), 3),
+        (Integer(16), 4),
+        (Symbol("x"), ntz(Symbol("x"))),
     ],
 )
-def test_ntz_parametrized(value, expected, raises, match):
-    if raises:
-        with pytest.raises(raises, match=match):
-            ntz(value)
-    else:
-        assert ntz(value) == expected
+def test_ntz_parametrized(value, expected):
+    assert ntz(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        (1.5, r"ntz requires integer argument; found 1\.5+"),
+        (10.0, r"ntz requires integer argument; found 10\.0+"),
+    ],
+)
+def test_ntz_raises_type_error_for_floating_point_input(value, match):
+    with pytest.raises(TypeError, match=match):
+        _ = ntz(value)
+
+
+@pytest.mark.parametrize(("value", "expected"), [(0, -1), (1, 0), (16, 4)])
+def test_substituting_values_into_symbolic_ntz_gives_correct_numeric_results(value, expected):
+    expr = ntz(x)
+
+    assert expr.subs({x: value}) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        (-1, "ntz requires non-negative integer; found -1"),
+        (Integer(-5), "ntz requires non-negative integer; found -5"),
+    ],
+)
+def test_ntz_raises_value_error_for_negative_integers(value, match):
+    with pytest.raises(ValueError, match=match):
+        _ = ntz(value)
 
 
 def test_fn_overrides_works_as_expected():


### PR DESCRIPTION
## Description

This PR makes `ntz(0)` equal to -1, as discussed via other communication channels.

Also cleans up relevant test cases.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.