### PR TITLE
feat: add rewrite_routine_resources

### DIFF
--- a/src/bartiq/analysis/rewriters/expression.py
+++ b/src/bartiq/analysis/rewriters/expression.py
@@ -16,9 +16,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import Generic
+from typing import Generic, TypeVar
 
 from typing_extensions import Self
 
@@ -232,3 +232,61 @@ class ExpressionRewriter(ABC, Generic[T]):
             linked_symbols=self.linked_symbols | substitution.linked_symbols,
             _previous=(substitution, self),
         )
+
+    def with_instructions(self, instructions: Sequence[Instruction]) -> Self:
+        """Apply a sequence of instructions.
+
+        Sequentially apply each instruction in the provided list to the
+        expression, with each instruction being applied to the result of
+        the previous one.
+
+        Args:
+            instructions: A list of Instructions to apply in order. Each
+                instruction will be applied to the result of the previous
+                instruction.
+
+        Returns:
+            A new ExpressionRewriter instance with all instructions applied.
+
+        Examples:
+            Apply expand, simplify, and an assumption:
+
+                >>> rewriter.with_instructions(
+                ...     [Expand(), Simplify(), Assumption("x>0")]
+                ... )
+
+        """
+        rewriter = self
+        for instruction in instructions:
+            rewriter = _apply_instruction(rewriter, instruction)
+        return rewriter
+
+
+ExpressionRewriterT = TypeVar("ExpressionRewriterT", bound="ExpressionRewriter")
+
+
+def _apply_instruction(rewriter: ExpressionRewriterT, instruction: Instruction) -> ExpressionRewriterT:
+    """Helper function to apply instructions to a rewriter instance.
+    Args:
+        rewriter: Rewriter to apply an instruction to.
+        instruction: Instruction to apply.
+    Raises:
+        ValueError: If an unrecognised instruction is passed.
+    Returns:
+        A new expression rewriter instance.
+    """
+    match instruction:
+        case Initial():
+            return rewriter
+        case Expand():
+            return rewriter.expand()
+        case Simplify():
+            return rewriter.simplify()
+        case Assumption():
+            return rewriter.assume(instruction)
+        case Substitution():
+            return rewriter.substitute(instruction.expr, instruction.replacement)
+        case ReapplyAllAssumptions():
+            return rewriter.reapply_all_assumptions()
+        case _:
+            raise ValueError(f"Unrecognised instruction: '{instruction}'.")

--- a/src/bartiq/analysis/rewriters/routine_rewriter.py
+++ b/src/bartiq/analysis/rewriters/routine_rewriter.py
@@ -1,0 +1,83 @@
+# Copyright 2025 PsiQuantum, Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Here we provide functionality to allow you to apply rewriters to CompiledRoutine resource expressions"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Protocol
+
+from bartiq import CompiledRoutine
+from bartiq.analysis.rewriters.expression import ExpressionRewriter
+from bartiq.analysis.rewriters.sympy_expression import sympy_rewriter
+from bartiq.analysis.rewriters.utils import Instruction
+from bartiq.compilation._common import Resource
+from bartiq.symbolics.backend import T
+
+
+class ExpressionRewriterFactory(Protocol[T]):
+    """A protocol for generating expression rewriters."""
+
+    def __call__(self, expression: str | T) -> ExpressionRewriter[T]: ...
+
+
+def rewrite_routine_resources(
+    routine: CompiledRoutine,
+    resources: str | Iterable[str],
+    instructions: list[Instruction],
+    rewriter_factory: ExpressionRewriterFactory = sympy_rewriter,
+) -> CompiledRoutine:
+    """Rewrite the resources of a CompiledRoutine object with a given list of instructions.
+
+    Args:
+        routine: A CompiledRoutine object.
+        resources: Resource name(s) to apply the instructions to.
+        instructions: A list of rewriter instructions to apply.
+        rewriter_factory: A factory function that instantiates a rewriter. By default sympy_rewriter.
+
+    Returns:
+        A new CompiledRoutine object.
+    """
+
+    def _traverse_routine(routine: CompiledRoutine, resource_to_rewrite: str) -> CompiledRoutine:
+        """Recursively traverse the routine, replacing resource values
+        starting from the lowest level of children."""
+
+        new_children_dict: dict[str, CompiledRoutine] = {
+            child_name: _traverse_routine(child_routine, resource_to_rewrite)
+            for child_name, child_routine in routine.children.items()
+        }
+        if resource_to_rewrite in routine.resources and not isinstance(
+            routine.resource_values[resource_to_rewrite], (int | float)
+        ):
+            new_resource_dict: dict[str, Resource] = {
+                resource_to_rewrite: replace(
+                    routine.resources[resource_to_rewrite],
+                    value=rewriter_factory(routine.resources[resource_to_rewrite].value)
+                    .with_instructions(instructions)
+                    .expression,
+                )
+            }
+            return replace(
+                routine, children=routine.children | new_children_dict, resources=routine.resources | new_resource_dict
+            )
+
+        return routine
+
+    if isinstance(resources, str):
+        return _traverse_routine(routine, resources)
+
+    for resource in resources:
+        routine = _traverse_routine(routine, resource)
+    return routine

--- a/tests/analysis/rewriters/test_routine_rewriter.py
+++ b/tests/analysis/rewriters/test_routine_rewriter.py
@@ -1,0 +1,102 @@
+import pytest
+
+from bartiq import Routine, compile_routine
+from bartiq.analysis.rewriters.routine_rewriter import rewrite_routine_resources
+from bartiq.analysis.rewriters.sympy_expression import sympy_rewriter
+from bartiq.compilation import CompilationFlags
+
+
+def from_str_to_str(backend, expr: str):
+    """Remove assumptions from symbols and ensure string matching works"""
+    return str(backend.as_expression(expr))
+
+
+@pytest.fixture(scope="function")
+def root():
+    return {
+        "name": "root",
+        "children": [
+            {
+                "name": "a",
+                "children": [
+                    {
+                        "name": "b",
+                        "resources": [
+                            {"name": "dummy_a", "type": "additive", "value": "max(0, b)"},
+                            {"name": "dummy_b", "type": "additive", "value": "log(1 + b)"},
+                        ],
+                    },
+                    {
+                        "name": "c",
+                        "resources": [
+                            {"name": "dummy_a", "type": "additive", "value": "max(0, c)"},
+                            {"name": "dummy_b", "type": "additive", "value": "min(2, c)"},
+                        ],
+                    },
+                ],
+            },
+            {
+                "name": "x",
+                "children": [
+                    {
+                        "name": "y",
+                        "resources": [
+                            {"name": "dummy_a", "type": "additive", "value": "max(0, y)"},
+                            {"name": "dummy_b", "type": "additive", "value": "ceiling(y)"},
+                        ],
+                    },
+                    {
+                        "name": "z",
+                        "resources": [
+                            {"name": "dummy_a", "type": "additive", "value": "max(0, z)"},
+                            {"name": "dummy_b", "type": "additive", "value": "Heaviside(z, 0.5)"},
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture(scope="function")
+def compiled(root, backend):
+    return compile_routine(
+        Routine.from_qref(root, backend), compilation_flags=CompilationFlags.EXPAND_RESOURCES
+    ).routine
+
+
+def test_rewrite_routine_resources(compiled, backend):
+    resources = ["dummy_a", "dummy_b"]
+    rewriter = sympy_rewriter(compiled.resource_values["dummy_a"])
+    rewriter = (
+        rewriter.assume("b>0")
+        .assume("y>0")
+        .assume("z>10")
+        .assume("c>5")
+        .simplify()
+        .expand()
+        .substitute("y + z", "A")
+        .substitute("ceiling($x)", "x")
+    )
+    new_routine = rewrite_routine_resources(compiled, resources, rewriter.history(), sympy_rewriter)
+
+    # Test that the new routine top-level resource is the same as the rewriter attribute expression
+    print(rewriter.expression)
+    print(compiled.resource_values)
+    print(new_routine.resource_values)
+    assert new_routine.resource_values["dummy_a"] == rewriter.expression
+
+    # Test that the history has percolated through the children correctly.
+    # Dummy A resource
+    assert str(new_routine.children["a"].children["b"].resource_values["dummy_a"]) == from_str_to_str(backend, "b")
+    assert str(new_routine.children["x"].children["z"].resource_values["dummy_a"]) == from_str_to_str(backend, "z")
+
+    assert str(new_routine.children["a"].resource_values["dummy_a"]) == from_str_to_str(backend, "b+c")
+    assert str(new_routine.children["x"].resource_values["dummy_a"]) == from_str_to_str(backend, "A")
+
+    # Dummy B resource
+    assert str(new_routine.children["a"].children["c"].resource_values["dummy_b"]) == from_str_to_str(backend, "2")
+    assert str(new_routine.children["x"].children["z"].resource_values["dummy_b"]) == from_str_to_str(backend, "1")
+
+    assert str(new_routine.children["a"].resource_values["dummy_b"]) == from_str_to_str(backend, "log(b+1)+2")
+    assert str(new_routine.children["x"].resource_values["dummy_b"]) == from_str_to_str(backend, "y+1")


### PR DESCRIPTION
## Description

Adds `with_instructions` to `ExpressionRewriter` and `rewrite_routine_resources` capability.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have included test cases validating introduced feature/fix.
- [X] I have updated documentation.