### PR TITLE
fix: allow numbers to be passed into sympy_rewriter

### DIFF
--- a/src/bartiq/analysis/rewriters/sympy_expression.py
+++ b/src/bartiq/analysis/rewriters/sympy_expression.py
@@ -44,6 +44,8 @@ class SympyExpressionRewriter(ExpressionRewriter[Expr]):
 
     def __post_init__(self):
         self.backend = _SYMPY_BACKEND
+        if isinstance(self.expression, (int, float)):
+            self.expression = Number(self.expression)
 
     @property
     def original(self) -> Self:

--- a/tests/analysis/rewriters/test_sympy_rewriter.py
+++ b/tests/analysis/rewriters/test_sympy_rewriter.py
@@ -45,6 +45,10 @@ class TestSympyExpressionRewriter(ExpressionRewriterTests):
         assert expr.__class__.__module__.startswith("bartiq")
         assert cast_expr.__class__.__module__.startswith("sympy")
 
+    @pytest.mark.parametrize("input", [sympy.sympify("max(a, b, c)"), "max(a, b, c)", 0, 1.1])
+    def test_rewriter_accepts_all_input_types(self, input):
+        assert self.rewriter(input)
+
     def test_simplify(self, backend):
         expr = backend.as_expression("(a*a + b*a)*c + d*(log2(x)**2 + log2(x))")
         assert self.rewriter(expr).simplify().expression == expr.simplify()


### PR DESCRIPTION
## Description

To address #247.

Added a test to ensure the `Max` function is correctly replaced as well.


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.