### PR TITLE
fix: assumptions were not properly replacing symbols

### DIFF
--- a/src/bartiq/analysis/rewriters/sympy_expression.py
+++ b/src/bartiq/analysis/rewriters/sympy_expression.py
@@ -151,8 +151,9 @@ class SympyExpressionRewriter(ExpressionRewriter[Expr]):
             expression = expression.subs({reference_symbol: replacement})
             reference_symbol = replacement
         else:
-            reference_symbol = self.backend.as_expression(assumption.symbol_name)
-
+            reference_symbol = (expr := self.backend.as_expression(assumption.symbol_name)).subs(
+                {fs: sym for fs in expr.free_symbols if (sym := self.get_symbol(fs.name))}
+            )
         replacement_symbol = Symbol(name="__", **assumption.symbol_properties)
         # This is a hacky way to implement assumptions that relate to nonzero values.
         expression = expression.subs({reference_symbol: replacement_symbol + assumption.value}).subs(

--- a/tests/analysis/rewriters/test_sympy_rewriter.py
+++ b/tests/analysis/rewriters/test_sympy_rewriter.py
@@ -136,6 +136,10 @@ class TestSympyExpressionRewriter(ExpressionRewriterTests):
         assert str(rewriter.expression) == simplified_expression
         assert getattr(rewriter.get_symbol(symbol), property)
 
+    def test_add_assumption_properly_replaces_symbols_with_assumptions(self, backend):
+        rewriter = self.rewriter("max(0, a+b)").assume("a>0")
+        assert str(rewriter.assume("a+b>0").expression) == str(backend.as_expression("a + b"))
+
     def test_more_complex_expressions_have_assumptions_applied(self, backend):
         expr = "b*max(1 + log(2*x/5), 5) + c * d"
         rewriter = self.rewriter(expr).assume("log(2*x/5) > 4")


### PR DESCRIPTION
## Description

Bugfix. The logic for applying assumptions to expressions was not detecting already existing symbols and the assumptions on them, e.g.:

```python
rewriter = sympy_rewriter("max(0, a + b)").assume("a>0")
rewriter.assume("a+b > 0")
>>> max(0, a + b)
```
This is because, when applying assumptions to _expressions_ (rather than symbols), any existing symbols in the expression were not being replaced, and so in the above example the `a` in `a+b` is parsed into sympy, but is _different_ from the `a` already present, which is defined as nonnegative and positive. This PR fixes that!

I added a test to catch this logic. 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.