### PR TITLE
docs: fix links reported as broken

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,18 +5,20 @@
 Bartiq is a Python library for compiling and analyzing fault-tolerant quantum algorithms to understand their computational requirements. It focuses on Quantum Resource Estimation (QRE), tracking key logical-level resources including T-gates, Toffolis, circuit active volume, and qubit count. In `bartiq`, quantum algorithms are expressed as subroutines with locally defined symbolic resource costs, which are used by its compilation engine to generate global resource costs from these local definitions.
 
 To install `bartiq` via `pip`, run
+
 ```bash
 pip install bartiq
 ```
- More detailed instructions can be found on the [installation page](installation.md).
+
+> It is recommended to install bartiq as part of the psiqdk package. More detailed instructions can be found on the [installation page](https://construct.psiquantum.com/docs/psiqdk/installation.html).
 
 ## Quick start
-As an example we consider the following circuit, from [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.8.041015). This circuit prepares an arbitrary state with $L$ unique amplitudes, and is equivalent to classical alias sampling. From Fig. 11 in the paper:
+
+As an example we consider the following circuit from "Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity" ([arXiv:1805.03662](https://arxiv.org/abs/1805.03662)). This circuit prepares an arbitrary state with $L$ unique amplitudes, and is equivalent to classical alias sampling. From Fig. 11 in the paper:
 
 ![Alias Sampling](images/alias_sampling_paper.png)
 
 In order to quickly get started with `bartiq`, you can load this as an example routine and use it as follows (click here to download <a href="https://raw.githubusercontent.com/PsiQ/bartiq/main/docs/data/alias_sampling_basic.json" download>`alias_sampling_basic.json`</a>):
-
 
 ```python
 import json
@@ -29,9 +31,11 @@ with open("alias_sampling_basic.json", "r") as f:
 uncompiled_routine = SchemaV1(**routine_dict)
 compiled_routine = compile_routine(uncompiled_routine).routine
 ```
+
 After loading the alias sampling JSON file we cast it to the [`qref.SchemaV1`](https://github.com/PsiQ/qref/blob/main/src/qref/schema_v1.py) type, our [data format](https://github.com/PsiQ/qref) for representing quantum algorithms for the purposes for resource estimation. This provides us with an `uncompiled_routine`, which we can then compile with [`compile_routine`][bartiq.compile_routine]. The compilation engine will propagate the resource costs from low-level subroutines up, to create aggregated global costs for the whole circuit. 
 
 To see, for example, the symbolic $T$-gate count for this circuit:
+
 ```python
 print(compiled_routine.resources["T_gates"].value)
 >>> 4*L + 8*L/multiplicity(2, L) + 4*mu + O(log2(L)) - 8
@@ -48,6 +52,7 @@ print(evaluated_routine.resources["T_gates"].value)
 ```
 
 As `bartiq` is primarily symbolic in nature, we do not have to assign values for all of our variables:
+
 ```python
 assignments = { "mu": 10}
 evaluated_routine = evaluate(compiled_routine, assignments).routine
@@ -55,6 +60,7 @@ evaluated_routine = evaluate(compiled_routine, assignments).routine
 print(evaluated_routine.resources["T_gates"].value)
 >>> 4*L + 8*L/multiplicity(2, L) + O(log2(L)) + 32
 ```
+
 ## Next steps
 
 - For more comprehensive examples, please see the [tutorials](tutorials/index.md).

--- a/docs/tutorials/02_alias_sampling_basic.ipynb
+++ b/docs/tutorials/02_alias_sampling_basic.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "The example we used in previous tutorial was nice to establish some basic terminology. But let's be honest, it was contrived and not very practical. So now we'll take a practical algorithm from a paper and try to get some resource estimations for it using `bartiq`!\n",
     "\n",
-    "We'll use Alias Sampling —-- an algorithm proposed by Babbush et al. in [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.8.041015). This is what the circuit looks like:\n",
+    "We'll use Alias Sampling —-- an algorithm proposed by Babbush et al. in \"Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity\" ([arXiv:1805.03662](https://arxiv.org/abs/1805.03662)). This is what the circuit looks like:\n",
     "\n",
     "![Alias Sampling](../images/alias_sampling_paper.png)\n",
     "\n",


### PR DESCRIPTION
## Description

Fixed a couple of links that either are reported as broken by robots while accessible to a human (an arxiv mirror works fine for both) or point to pages that are not included in the Construct docs and thus are broken there.

## Please verify that you have completed the following steps

- [x] I have updated documentation.